### PR TITLE
fix: downgrade hashconnect from v0.2.2-> v0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
     "framer-motion": "^6.5.0",
-    "hashconnect": "^0.2.2",
+    "hashconnect": "^0.1.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",

--- a/src/hooks/useHashConnect/useHashConnectEvents.ts
+++ b/src/hooks/useHashConnect/useHashConnectEvents.ts
@@ -51,7 +51,7 @@ const useHashConnectEvents = (
     hashconnect.foundExtensionEvent.on(handleFoundExtensionEvent);
     hashconnect.pairingEvent.on(handlePairingEvent);
     hashconnect.acknowledgeMessageEvent.on(handleAcknowledgeMessageEvent);
-    hashconnect.connectionStatusChangeEvent.on(handleConnectionStatusChange);
+    hashconnect.connectionStatusChange.on(handleConnectionStatusChange);
     hashconnect.transactionEvent.on(handleTransactionEvent);
     hashconnect.additionalAccountRequestEvent.on(handleAdditionalAccountRequestEvent);
 
@@ -60,7 +60,7 @@ const useHashConnectEvents = (
       hashconnect.foundExtensionEvent.off(handleFoundExtensionEvent);
       hashconnect.pairingEvent.off(handlePairingEvent);
       hashconnect.acknowledgeMessageEvent.off(handleAcknowledgeMessageEvent);
-      hashconnect.connectionStatusChangeEvent.off(handleConnectionStatusChange);
+      hashconnect.connectionStatusChange.off(handleConnectionStatusChange);
       hashconnect.transactionEvent.off(handleTransactionEvent);
       hashconnect.additionalAccountRequestEvent.off(handleAdditionalAccountRequestEvent);
     };
@@ -73,7 +73,7 @@ const useHashConnectEvents = (
     handleTransactionEvent,
     handleAdditionalAccountRequestEvent,
     hashconnect.acknowledgeMessageEvent,
-    hashconnect.connectionStatusChangeEvent,
+    hashconnect.connectionStatusChange,
     hashconnect.foundExtensionEvent,
     hashconnect.pairingEvent,
     hashconnect.transactionEvent,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9061,10 +9061,10 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hashconnect@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/hashconnect/-/hashconnect-0.2.2.tgz#33c06d350dab02b1c2691a713200594c7a1da65f"
-  integrity sha512-1h4VClayyJR3XdqCUGDXfz2TecIMNFXIv1bRx1QT705BONKafRh6S2amoauvS9LF72gLi2ox/abK8TM9Xybcbg==
+hashconnect@^0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/hashconnect/-/hashconnect-0.1.10.tgz#f66e941c2e72c88c8770664c57fac91b8bb4a6c9"
+  integrity sha512-w4lxJLDZk9cJ+x9OXEVZjt4JRY38tVOKkzMrBfyJoWw+Dyx+6GUSgW4k3XUFzqk8p0/ZKlf3ficu8/nPL1FSwQ==
   dependencies:
     "@hashgraph/sdk" "^2.14.2"
     buffer "^6.0.3"


### PR DESCRIPTION
**Description**:

Upgrading `hashconnect` from `0.1.0` to `0.2.2` breaks the wallet pairing functionality. We are reverting this upgrade for now.
