### PR TITLE
feat: spot price display and update to token to receive calculation

### DIFF
--- a/src/HederaOpenDEX/pages/Trade/Trade.tsx
+++ b/src/HederaOpenDEX/pages/Trade/Trade.tsx
@@ -13,6 +13,8 @@ const Trade = () => {
     spotPrices,
     sendSwapTransaction,
     fetchSpotPrices,
+    getPoolLiquidity,
+    poolLiquidity,
   } = useHashConnectContext();
   return (
     <HStack>
@@ -26,6 +28,8 @@ const Trade = () => {
             clearWalletPairings={clearWalletPairings}
             fetchSpotPrices={fetchSpotPrices}
             spotPrices={spotPrices}
+            getPoolLiquidity={getPoolLiquidity}
+            poolLiquidity={poolLiquidity}
             walletData={walletData}
             network={network}
             installedExtensions={installedExtensions}

--- a/src/components/Swap/Swap.tsx
+++ b/src/components/Swap/Swap.tsx
@@ -15,6 +15,8 @@ import {
   setTokenToReceiveBalance,
   swapTokenToTradeAndReceive,
   setSpotPrice,
+  setTokenToTradePoolLiquidity,
+  setTokenToReceivePoolLiquidity,
 } from "./actions/swapActions";
 import { Button, IconButton, SwapConfirmation } from "../base";
 import { TokenInput } from "../TokenInput/TokenInput";
@@ -27,8 +29,10 @@ export interface SwapProps {
   connectToWallet: () => void;
   clearWalletPairings: () => void;
   fetchSpotPrices: () => void;
+  getPoolLiquidity: (tokenToTrade: string, tokenToReceive: string) => void;
   connectionStatus: WalletConnectionStatus;
   spotPrices: Map<string, number | undefined> | undefined;
+  poolLiquidity: Map<string, number | undefined> | undefined;
   walletData: any | null;
   network: Networks;
   metaData?: HashConnectTypes.AppMetadata;
@@ -36,9 +40,72 @@ export interface SwapProps {
 }
 
 const Swap = (props: SwapProps) => {
-  const { title, spotPrices, walletData, connectionStatus, connectToWallet, sendSwapTransaction } = props;
+  const {
+    title,
+    spotPrices,
+    walletData,
+    connectionStatus,
+    connectToWallet,
+    sendSwapTransaction,
+    poolLiquidity,
+    getPoolLiquidity,
+  } = props;
   const [swapState, dispatch] = useImmerReducer(swapReducer, initialSwapState, initSwapReducer);
   const { tokenToTrade, tokenToReceive, spotPrice } = swapState;
+
+  // TODO: probably want to use usePrevious instead so we dont need this. right now, without this on symbol change it
+  //         updates spot price which then causes logic to run to calculate tokenToReceive amount but it uses the old
+  //        liquidity value of whichever token was just selected previously
+  useEffect(() => {
+    if (swapState.tokenToTrade.amount && swapState.tokenToTrade.symbol !== swapState.tokenToReceive.symbol) {
+      const tokenToReceiveAmount = getReceivedAmount(tokenToTrade.amount);
+      dispatch(setTokenToReceiveAmount(tokenToReceiveAmount || 0));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [swapState.tokenToTrade.poolLiquidity, swapState.tokenToReceive.poolLiquidity]);
+
+  /**
+   * Whenever poolLiquidity is updated (ie new pair selected) update
+   * poolLiquidity for each token in swapState accordingly
+   */
+  useEffect(() => {
+    if (poolLiquidity !== undefined && poolLiquidity instanceof Map) {
+      const tokenToTradeSymbol = swapState.tokenToTrade.symbol || "";
+      const tokenToReceiveSymbol = swapState.tokenToReceive.symbol || "";
+      dispatch(setTokenToTradePoolLiquidity(poolLiquidity.get(tokenToTradeSymbol)));
+      dispatch(setTokenToReceivePoolLiquidity(poolLiquidity.get(tokenToReceiveSymbol)));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [poolLiquidity, dispatch]);
+
+  /**
+   * Gets price impact based on liquidity values in pool
+   * before and after proposed swap
+   */
+  const priceImpact = useCallback(() => {
+    if (
+      swapState.tokenToTrade.poolLiquidity &&
+      swapState.tokenToReceive.poolLiquidity &&
+      swapState.tokenToTrade.amount &&
+      swapState.tokenToReceive.amount &&
+      swapState.tokenToTrade.symbol !== swapState.tokenToReceive.symbol
+    ) {
+      const amountReceived = getReceivedAmount(swapState.tokenToTrade.amount) || 1;
+      const newSpotPrice = amountReceived / swapState.tokenToTrade.amount;
+      const _priceImpact = ((swapState.spotPrice || 1) / newSpotPrice - 1) * 100;
+      return `${_priceImpact.toFixed(2)}%`;
+    } else {
+      return "--";
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    swapState.tokenToTrade.poolLiquidity,
+    swapState.tokenToReceive.poolLiquidity,
+    swapState.tokenToTrade.amount,
+    swapState.tokenToReceive.amount,
+    swapState.tokenToTrade.symbol,
+    swapState.tokenToReceive.symbol,
+  ]);
 
   const getTokenBalance = useCallback(
     (tokenSymbol: string): number => {
@@ -66,12 +133,39 @@ const Swap = (props: SwapProps) => {
     [dispatch, spotPrices, tokenToTrade.symbol, tokenToReceive.symbol]
   );
 
+  /**
+   * Calculates the token to receive amount based on the tokenToTradeAmount input.
+   * Follows the x*y=K formula where x and y are the amounts of each token's liquidity.
+   * K remains constant after a transaction, so it is safe to assume (post trade)
+   * newX*newY = K. Therefore, taking the tokenToTradeAmount and adding it to the current
+   * liquidity of the tokenToTrade in the pool, we get "newX". Taking k/newX, we can compute
+   * newY. We then subtract the newY from the current liquidty of Y to get the tokenToReceive amount
+   */
+  const getReceivedAmount = useCallback(
+    (tokenToTradeAmount: number) => {
+      if (tokenToTrade.poolLiquidity && tokenToReceive.poolLiquidity) {
+        // TODO: pull k from contract?
+        const k = tokenToTrade.poolLiquidity * tokenToReceive.poolLiquidity;
+        const postSwapTokenToTradeLiquidity = tokenToTrade?.poolLiquidity + tokenToTradeAmount;
+        const postSwapTokenToReceiveLiquidity = k / postSwapTokenToTradeLiquidity;
+        const amountToReceive = tokenToReceive.poolLiquidity - postSwapTokenToReceiveLiquidity;
+        return +amountToReceive; // TODO: check this decimal value
+      } else {
+        return undefined;
+      }
+    },
+    [tokenToTrade.poolLiquidity, tokenToReceive.poolLiquidity]
+  );
+
   /** Update token to receive amount any time the token symbols, token to trade amount, or spot price is updated. */
   useEffect(() => {
     if (spotPrice !== undefined) {
-      const tokenToReceiveAmount = getTokenExchangeAmount(tokenToTrade.amount, spotPrice);
-      dispatch(setTokenToReceiveAmount(tokenToReceiveAmount));
+      // TODO: check on if we should keep getTokenExcchangeAmount
+      // const tokenToReceiveAmount = getTokenExchangeAmount(tokenToTrade.amount, spotPrice);
+      const tokenToReceiveAmount = getReceivedAmount(tokenToTrade.amount);
+      dispatch(setTokenToReceiveAmount(tokenToReceiveAmount || 0));
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, spotPrice, tokenToTrade.amount]);
 
   /** Update balances any time the token symbols or the cached paired account balances change. */
@@ -79,11 +173,25 @@ const Swap = (props: SwapProps) => {
     if (tokenToTrade.symbol !== undefined) {
       const tokenToTradeBalance = getTokenBalance(tokenToTrade.symbol);
       dispatch(setTokenToTradeBalance(tokenToTradeBalance));
+      if (poolLiquidity !== undefined && poolLiquidity instanceof Map) {
+        dispatch(setTokenToTradePoolLiquidity(poolLiquidity?.get(tokenToTrade.symbol)));
+      }
     }
     if (tokenToReceive.symbol !== undefined) {
       const tokenToReceiveBalance = getTokenBalance(tokenToReceive.symbol);
       dispatch(setTokenToReceiveBalance(tokenToReceiveBalance));
+      if (poolLiquidity !== undefined && poolLiquidity instanceof Map) {
+        dispatch(setTokenToReceivePoolLiquidity(poolLiquidity?.get(tokenToReceive.symbol)));
+      }
     }
+
+    // get pool liquidity for selected symbols
+    // TODO: revisit this approach
+    if (tokenToTrade.symbol && tokenToReceive.symbol) {
+      // TODO: should we use usePrevious here to only make this call when the selected token has changed?
+      getPoolLiquidity(tokenToTrade.symbol, tokenToReceive.symbol);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, getTokenBalance, tokenToTrade.symbol, tokenToReceive.symbol, walletData?.pairedAccountBalance]);
 
   const handleTokenToTradeAmountChange = useCallback(
@@ -231,7 +339,7 @@ const Swap = (props: SwapProps) => {
           <Box flex="2">
             <Text fontSize="xs">Price Impact</Text>
             <Text fontSize="xs" fontWeight="bold">
-              --
+              {priceImpact()}
             </Text>
           </Box>
           <Box flex="4">

--- a/src/components/Swap/__fixtures__/swap.ts
+++ b/src/components/Swap/__fixtures__/swap.ts
@@ -8,7 +8,9 @@ export const mockSwapProps: SwapProps = {
   connectToWallet: () => null,
   clearWalletPairings: () => null,
   fetchSpotPrices: () => null,
+  getPoolLiquidity: () => null,
   spotPrices: undefined,
+  poolLiquidity: undefined,
   walletData: null,
   network: "testnet",
   metaData: {

--- a/src/components/Swap/actions/swapActions.ts
+++ b/src/components/Swap/actions/swapActions.ts
@@ -14,6 +14,10 @@ const setTokenToTradeBalance = (balance: number | undefined): SwapAction => {
   return { type: ActionType.SET_TOKEN_TO_TRADE, field: "balance", payload: balance };
 };
 
+const setTokenToTradePoolLiquidity = (amount: number | undefined): SwapAction => {
+  return { type: ActionType.SET_TOKEN_TO_TRADE, field: "poolLiquidity", payload: amount };
+};
+
 /** SET TOKEN TO RECEIVE ACTION CREATORS */
 
 const setTokenToReceiveAmount = (amount: number): SwapAction => {
@@ -26,6 +30,10 @@ const setTokenToReceiveSymbol = (symbol: string | undefined): SwapAction => {
 
 const setTokenToReceiveBalance = (balance: number | undefined): SwapAction => {
   return { type: ActionType.SET_TOKEN_TO_RECEIVE, field: "balance", payload: balance };
+};
+
+const setTokenToReceivePoolLiquidity = (amount: number | undefined): SwapAction => {
+  return { type: ActionType.SET_TOKEN_TO_RECEIVE, field: "poolLiquidity", payload: amount };
 };
 
 /** SET TOKEN TO RECEIVE ACTION CREATORS */
@@ -44,9 +52,11 @@ export {
   setTokenToTradeAmount,
   setTokenToTradeSymbol,
   setTokenToTradeBalance,
+  setTokenToTradePoolLiquidity,
   setTokenToReceiveAmount,
   setTokenToReceiveSymbol,
   setTokenToReceiveBalance,
+  setTokenToReceivePoolLiquidity,
   swapTokenToTradeAndReceive,
   setSpotPrice,
 };

--- a/src/components/Swap/reducers/swapReducer.tsx
+++ b/src/components/Swap/reducers/swapReducer.tsx
@@ -6,11 +6,13 @@ const initialSwapState: SwapState = {
     symbol: "HBAR",
     amount: 0.0,
     balance: undefined,
+    poolLiquidity: undefined,
   },
   tokenToReceive: {
     symbol: undefined,
     amount: 0.0,
     balance: undefined,
+    poolLiquidity: undefined,
   },
   spotPrice: undefined,
 };

--- a/src/components/Swap/types.ts
+++ b/src/components/Swap/types.ts
@@ -3,11 +3,13 @@ export interface SwapState {
     symbol: string | undefined;
     amount: number;
     balance: number | undefined;
+    poolLiquidity: number | undefined;
   };
   tokenToReceive: {
     symbol: string | undefined;
     amount: number;
     balance: number | undefined;
+    poolLiquidity: number | undefined;
   };
   spotPrice: number | undefined;
 }

--- a/src/context/HashConnectContext.tsx
+++ b/src/context/HashConnectContext.tsx
@@ -20,10 +20,12 @@ export interface HashConnectContextProps {
   connectToWallet: () => void;
   clearWalletPairings: () => void;
   fetchSpotPrices: () => void;
+  getPoolLiquidity: (tokenToTrade: string, tokenToReceive: string) => void;
   connectionStatus: WalletConnectionStatus;
   walletData: any | null;
   network: Networks;
   spotPrices: Map<string, number | undefined> | undefined;
+  poolLiquidity: Map<string, number | undefined> | undefined;
   metaData?: HashConnectTypes.AppMetadata;
   installedExtensions: HashConnectTypes.WalletMetadata[] | null;
 }
@@ -34,10 +36,12 @@ const HashConnectContext = React.createContext<HashConnectContextProps>({
   connectToWallet: () => null,
   clearWalletPairings: () => null,
   fetchSpotPrices: () => null,
+  getPoolLiquidity: () => null,
   connectionStatus: WalletConnectionStatus.INITIALIZING,
   walletData: null,
   network: "testnet",
   spotPrices: undefined,
+  poolLiquidity: undefined,
   installedExtensions: null,
 });
 
@@ -60,14 +64,20 @@ const HashConnectProvider = ({
     init,
     [loggerMiddleware, thunkMiddleware]
   );
-  const { connectToWallet, clearWalletPairings, sendSwapTransaction, fetchSpotPrices, sendAddLiquidityTransaction } =
-    useHashConnect({
-      hashConnectState,
-      dispatch,
-      network,
-      dexMetaData,
-      debug,
-    });
+  const {
+    connectToWallet,
+    clearWalletPairings,
+    sendSwapTransaction,
+    fetchSpotPrices,
+    sendAddLiquidityTransaction,
+    getPoolLiquidity,
+  } = useHashConnect({
+    hashConnectState,
+    dispatch,
+    network,
+    dexMetaData,
+    debug,
+  });
 
   return (
     <HashConnectContext.Provider
@@ -78,6 +88,8 @@ const HashConnectProvider = ({
         clearWalletPairings,
         fetchSpotPrices,
         spotPrices: hashConnectState.spotPrices,
+        getPoolLiquidity,
+        poolLiquidity: hashConnectState.poolLiquidity,
         connectionStatus: hashConnectState.walletConnectionStatus,
         walletData: hashConnectState.walletData,
         network,

--- a/src/hooks/useHashConnect/actions/actionsTypes.ts
+++ b/src/hooks/useHashConnect/actions/actionsTypes.ts
@@ -28,6 +28,9 @@ export enum ActionType {
   WALLET_PAIRING_APPROVED = "WALLET_PAIRING_APPROVED",
   RECEIVED_CONNECTION_STATUS_CHANGED = "RECEIVED_CONNECTION_STATUS_CHANGED",
   LOCAL_CONNECTION_STATUS_CHANGED = "LOCAL_CONNECTION_STATUS_CHANGED",
+  FETCH_POOL_LIQUIDITY_STARTED = "FETCH_POOL_LIQUIDITY_STARTED",
+  FETCH_POOL_LIQUIDITY_SUCCEEDED = "FETCH_POOL_LIQUIDITY_SUCCEEDED",
+  FETCH_POOL_LIQUIDITY_FAILED = "FETCH_POOL_LIQUIDITY_FAILED",
 }
 
 type AsyncAction = (dispatch: (action: any) => any) => void;
@@ -165,6 +168,22 @@ interface ReceivedConnectionStatusChanged {
   payload: ConnectionStatus;
 }
 
+/** FETCH_POOL_LIQUIDITY Action Types */
+
+interface FetchPoolLiquidityStarted {
+  type: ActionType.FETCH_POOL_LIQUIDITY_STARTED;
+}
+
+interface FetchPoolLiquiditySucceeded {
+  type: ActionType.FETCH_POOL_LIQUIDITY_SUCCEEDED;
+  payload: any; // PoolLiquidityJson;
+}
+
+interface FetchPoolLiquidityFailed {
+  type: ActionType.FETCH_POOL_LIQUIDITY_FAILED;
+  payload: string;
+}
+
 export type HashConnectAction =
   | AsyncAction
   | InitializeWalletConnectionStarted
@@ -182,6 +201,9 @@ export type HashConnectAction =
   | FetchSpotPricesStarted
   | FetchSpotPricesSucceeded
   | FetchSpotPricesFailed
+  | FetchPoolLiquidityStarted
+  | FetchPoolLiquiditySucceeded
+  | FetchPoolLiquidityFailed
   | SendSwapTransactionToWalletStarted
   | SendSwapTransactionToWalletSucceeded
   | SendSwapTransactionToWalletFailed

--- a/src/hooks/useHashConnect/reducers/hashConnectReducer.ts
+++ b/src/hooks/useHashConnect/reducers/hashConnectReducer.ts
@@ -7,6 +7,7 @@ import { WalletConnectionStatus } from "../types";
 export interface HashConnectState {
   errorMessage: string | null;
   spotPrices: Map<string, number | undefined> | undefined;
+  poolLiquidity: Map<string, number | undefined> | undefined;
   walletConnectionStatus: WalletConnectionStatus;
   installedExtensions: HashConnectTypes.WalletMetadata[];
   walletData: {
@@ -24,6 +25,7 @@ export interface HashConnectState {
 const initialHashConnectState: HashConnectState = {
   errorMessage: null,
   spotPrices: undefined,
+  poolLiquidity: undefined,
   walletConnectionStatus: WalletConnectionStatus.INITIALIZING,
   installedExtensions: [],
   walletData: {
@@ -129,6 +131,23 @@ function hashConnectReducer(state: HashConnectState, action: HashConnectAction):
       };
     }
     case ActionType.FETCH_SPOT_PRICES_FAILED: {
+      const { payload } = action;
+      return {
+        ...state,
+        errorMessage: payload,
+      };
+    }
+    case ActionType.FETCH_POOL_LIQUIDITY_STARTED: {
+      return state;
+    }
+    case ActionType.FETCH_POOL_LIQUIDITY_SUCCEEDED: {
+      const { payload } = action;
+      return {
+        ...state,
+        poolLiquidity: payload,
+      };
+    }
+    case ActionType.FETCH_POOL_LIQUIDITY_FAILED: {
       const { payload } = action;
       return {
         ...state,

--- a/src/hooks/useHashConnect/useHashConnect.ts
+++ b/src/hooks/useHashConnect/useHashConnect.ts
@@ -9,6 +9,7 @@ import {
   sendSwapTransactionToWallet,
   sendAddLiquidityTransactionToWallet,
   fetchSpotPrices,
+  getPoolLiquidity,
 } from "./actions/hashConnectActions";
 import { HashConnectState } from "./reducers/hashConnectReducer";
 import { useHashConnectEvents } from "./useHashConnectEvents";
@@ -80,6 +81,8 @@ const useHashConnect = ({
     sendSwapTransaction: (payload: any) =>
       dispatch(sendSwapTransactionToWallet({ ...payload, hashconnect, hashConnectState, network })),
     fetchSpotPrices: () => dispatch(fetchSpotPrices()),
+    getPoolLiquidity: (tokenToTrade: string, tokenToReceive: string) =>
+      dispatch(getPoolLiquidity(tokenToTrade, tokenToReceive)),
     sendAddLiquidityTransaction: (payload: any) =>
       dispatch(sendAddLiquidityTransactionToWallet({ ...payload, hashconnect, hashConnectState, network })),
     clearWalletPairings,

--- a/src/hooks/useHederaService/swapContract.ts
+++ b/src/hooks/useHederaService/swapContract.ts
@@ -241,17 +241,20 @@ const get100LABTokens = async (receivingAccoundId: string) => {
   console.log("The transaction consensus status " + transactionStatus.toString());
 };
 
-const pairCurrentPosition = async () => {
+// TODO: will need to pass in contractId in future when there are more pools
+const pairCurrentPosition = async (_contractId: string = contractId) => {
   const getPairQty = new ContractExecuteTransaction()
-    .setContractId(contractId)
+    .setContractId(_contractId)
     .setGas(1000000)
     .setFunction("getPairQty")
     .freezeWith(client);
   const getPairQtyTx = await getPairQty.execute(client);
   const response = await getPairQtyTx.getRecord(client);
-  const tokenAQty = response.contractFunctionResult?.getInt64(0);
-  const tokenBQty = response.contractFunctionResult?.getInt64(1);
+  const tokenAQty = response.contractFunctionResult?.getInt64(0).toNumber();
+  const tokenBQty = response.contractFunctionResult?.getInt64(1).toNumber();
   console.log(`${tokenAQty} units of token A and ${tokenBQty} units of token B are present in the pool. \n`);
+  // TODO: dont hardcodethis, will have to be dynamic
+  return { L49A: tokenAQty, L49B: tokenBQty };
 };
 
 const getContributorTokenShare = async () => {
@@ -314,4 +317,5 @@ export {
   getContributorTokenShare,
   getTokenBalance,
   getSpotPrice,
+  pairCurrentPosition,
 };


### PR DESCRIPTION
Price impact display and updates to computation of calculating the token to receive value. Updated token to receive computation to abide by the CPMM algorithm where (X+newX)*(Y-newY) = K. Plug in values and solve for newY previously was using spot price directly 

A few issues/things to note:
-need to revisit the Swap calculation and make sure this is the correct way 
-when switching token selection, it makes a smart contract call to get the spot price. this has some latency and we should perhaps add some UX to show that price impact as well as the new price needs some time to be calculated (as we need to retrieve liquidity of both tokens to determine price impact as well as the token to receive value)
-There is a weird issue when clicking the switch token to trade and token to receive button (where the inputs are swapped). For some reason it is not a 1 to 1 match, the output value changes slightly. It is odd because it abides by the CPMM with the changed numbers, perhaps we have a precision or rounding error somewhere

<img width="817" alt="image" src="https://user-images.githubusercontent.com/100297531/190730705-dab05fcb-b582-49c3-b7dd-fa4d6d4e4e3b.png">
