### PR TITLE
feat: Updates to All & User Pool Metrics

### DIFF
--- a/src/HederaOpenDEX/HederaOpenDEX.tsx
+++ b/src/HederaOpenDEX/HederaOpenDEX.tsx
@@ -7,49 +7,6 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-d
 
 const menuOptions = ["Swap", "Pool"];
 
-// TODO: remove mocks
-const mockPoolsProps = {
-  allPoolsColHeaders: [
-    { headerName: "Pool", field: "name", colWidth: 158 },
-    { headerName: "Fee", field: "fee", colWidth: 61 },
-    { headerName: "TVL", field: "totalVolumeLocked", colWidth: 136 },
-    { headerName: "Volume 24H", field: "past24HoursVolume", colWidth: 136 },
-    { headerName: "Volume 7D", field: "past7daysVolume", colWidth: 136 },
-    { headerName: "Actions", field: "actions", colWidth: 203 },
-  ],
-  userPoolsColHeaders: [
-    { headerName: "Pool", colWidth: 158 },
-    { headerName: "Fee", colWidth: 61 },
-    { headerName: "Liquidity", colWidth: 136 },
-    { headerName: "% of the Pool", colWidth: 118 },
-    { headerName: "Unclaimed Fees", colWidth: 131 },
-    { headerName: "Actions", colWidth: 226 },
-  ],
-  userPools: [
-    {
-      Pool: "HBAR/USDT",
-      Fee: "0.05%",
-      Liquidity: "$123,456",
-      "% of the Pool": "<1%",
-      "Unclaimed Fees": "$4.56",
-    },
-    {
-      Pool: "HBAR/USDT",
-      Fee: "0.05%",
-      Liquidity: "$123,456",
-      "% of the Pool": "<1%",
-      "Unclaimed Fees": "$91.23",
-    },
-    {
-      Pool: "HBAR/USDT",
-      Fee: "0.05%",
-      Liquidity: "$123,456",
-      "% of the Pool": "100%",
-      "Unclaimed Fees": "$0.89",
-    },
-  ],
-};
-
 const HederaOpenDEX = () => {
   return (
     <ChakraProvider theme={HederaOpenDexTheme}>
@@ -59,7 +16,7 @@ const HederaOpenDEX = () => {
           <Routes>
             <Route path="/" element={<Navigate to="/swap" />} />
             <Route path="/swap" element={<Trade />} />
-            <Route path="/pool" element={<Pools {...mockPoolsProps} />} />
+            <Route path="/pool" element={<Pools />} />
             <Route path="/pool/add-liquidity" element={<Pool />} />
           </Routes>
         </Router>

--- a/src/HederaOpenDEX/HederaOpenDEX.tsx
+++ b/src/HederaOpenDEX/HederaOpenDEX.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { ChakraProvider, Container } from "@chakra-ui/react";
 import { Trade, Pool, Pools } from "./pages";
 import { TopMenuBar } from "./layouts/TopMenuBar";

--- a/src/HederaOpenDEX/pages/Pools/Pools.tsx
+++ b/src/HederaOpenDEX/pages/Pools/Pools.tsx
@@ -43,14 +43,19 @@ const userPoolsColHeaders: DataTableColumnConfig[] = [
 ];
 
 const Pools = (): JSX.Element => {
-  const { mirrorNodeState } = useHashConnectContext();
-  const { fetchAllPoolMetrics } = mirrorNodeState;
+  const { hashConnectState, mirrorNodeState } = useHashConnectContext();
+  const walletAccountId = hashConnectState.walletData.pairedAccounts[0];
+  const { fetchAllPoolMetrics, fetchUserPoolMetrics } = mirrorNodeState;
 
   const [colHeadersState, setState] = useState({ allPoolsColHeaders, userPoolsColHeaders });
 
   useEffect(() => {
-    fetchAllPoolMetrics();
-  }, [fetchAllPoolMetrics]);
+    const fetchPoolMetrics = async () => {
+      await fetchAllPoolMetrics();
+      await fetchUserPoolMetrics(walletAccountId);
+    };
+    fetchPoolMetrics();
+  }, [fetchAllPoolMetrics, fetchUserPoolMetrics, walletAccountId]);
 
   // Scales column width differences
   // TODO: check if we will need this, should be up to consumer of component to send proper values

--- a/src/HederaOpenDEX/pages/Pools/Pools.tsx
+++ b/src/HederaOpenDEX/pages/Pools/Pools.tsx
@@ -46,7 +46,7 @@ const Pools = (): JSX.Element => {
   const { mirrorNodeState } = useHashConnectContext();
   const { fetchAllPoolMetrics } = mirrorNodeState;
 
-  const [state, setState] = useState({ allPoolsColHeaders, userPoolsColHeaders });
+  const [colHeadersState, setState] = useState({ allPoolsColHeaders, userPoolsColHeaders });
 
   useEffect(() => {
     fetchAllPoolMetrics();
@@ -55,17 +55,28 @@ const Pools = (): JSX.Element => {
   // Scales column width differences
   // TODO: check if we will need this, should be up to consumer of component to send proper values
   useEffect(() => {
-    const allPoolsTotalColWidth = state.allPoolsColHeaders.reduce((total, col) => (total += col.colWidth), 0);
-    const userPoolsTotalColWidth = state.userPoolsColHeaders.reduce((total, col) => (total += col.colWidth), 0);
+    const allPoolsTotalColWidth = colHeadersState.allPoolsColHeaders.reduce((total, col) => (total += col.colWidth), 0);
+    const userPoolsTotalColWidth = colHeadersState.userPoolsColHeaders.reduce(
+      (total, col) => (total += col.colWidth),
+      0
+    );
     if (allPoolsTotalColWidth > userPoolsTotalColWidth) {
       setState({
-        ...state,
-        userPoolsColHeaders: scaleColWidth(state.userPoolsColHeaders, userPoolsTotalColWidth, allPoolsTotalColWidth),
+        ...colHeadersState,
+        userPoolsColHeaders: scaleColWidth(
+          colHeadersState.userPoolsColHeaders,
+          userPoolsTotalColWidth,
+          allPoolsTotalColWidth
+        ),
       });
     } else if (userPoolsTotalColWidth > allPoolsTotalColWidth) {
       setState({
-        ...state,
-        allPoolsColHeaders: scaleColWidth(state.allPoolsColHeaders, allPoolsTotalColWidth, userPoolsTotalColWidth),
+        ...colHeadersState,
+        allPoolsColHeaders: scaleColWidth(
+          colHeadersState.allPoolsColHeaders,
+          allPoolsTotalColWidth,
+          userPoolsTotalColWidth
+        ),
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -148,7 +159,7 @@ const Pools = (): JSX.Element => {
       </TabList>
       <TabPanels>
         <TabPanel>
-          <DataTable colHeaders={state.allPoolsColHeaders} rowData={getAllPoolsRowData()} />
+          <DataTable colHeaders={colHeadersState.allPoolsColHeaders} rowData={getAllPoolsRowData()} />
         </TabPanel>
         <TabPanel>
           {unclaimedFeeTotal() > 0 ? (
@@ -173,7 +184,7 @@ const Pools = (): JSX.Element => {
           ) : (
             ""
           )}
-          <DataTable colHeaders={state.userPoolsColHeaders} rowData={getUserPoolsRowData()} />
+          <DataTable colHeaders={colHeadersState.userPoolsColHeaders} rowData={getUserPoolsRowData()} />
         </TabPanel>
       </TabPanels>
     </Tabs>

--- a/src/HederaOpenDEX/pages/Pools/utils.ts
+++ b/src/HederaOpenDEX/pages/Pools/utils.ts
@@ -2,6 +2,12 @@ import { FormattedPoolDetails, FormattedUserPoolDetails } from ".";
 import { PoolState, UserPoolState } from "../../../hooks";
 import { formatToUSD, formatToPercent } from "../../utils";
 
+/**
+ * Coverts data associated with a liquidity pool into a format
+ * that will be displayed in the UI.
+ * @param poolState - Data associated with a liquidity pool.
+ * @returns A formatted version of the liquidity pool data.
+ */
 const formatPoolMetrics = (poolState: PoolState): FormattedPoolDetails => {
   return {
     name: poolState.name,
@@ -12,6 +18,12 @@ const formatPoolMetrics = (poolState: PoolState): FormattedPoolDetails => {
   };
 };
 
+/**
+ * Coverts data associated with a user's share of a liquidity pool
+ * into a format that will be displayed in the UI.
+ * @param userPoolState - Data associated with the user's share of a pool.
+ * @returns A formatted version of the user's liquidity pool data.
+ */
 const formatUserPoolMetrics = (userPoolState: UserPoolState): FormattedUserPoolDetails => {
   return {
     name: userPoolState.name,

--- a/src/HederaOpenDEX/pages/Pools/utils.ts
+++ b/src/HederaOpenDEX/pages/Pools/utils.ts
@@ -1,5 +1,5 @@
-import { FormattedPoolDetails } from ".";
-import { PoolState } from "../../../hooks";
+import { FormattedPoolDetails, FormattedUserPoolDetails } from ".";
+import { PoolState, UserPoolState } from "../../../hooks";
 import { formatToUSD, formatToPercent } from "../../utils";
 
 const formatPoolMetrics = (poolState: PoolState): FormattedPoolDetails => {
@@ -12,4 +12,14 @@ const formatPoolMetrics = (poolState: PoolState): FormattedPoolDetails => {
   };
 };
 
-export { formatPoolMetrics };
+const formatUserPoolMetrics = (userPoolState: UserPoolState): FormattedUserPoolDetails => {
+  return {
+    name: userPoolState.name,
+    fee: formatToPercent(userPoolState.fee),
+    liquidity: formatToUSD(userPoolState.liquidity),
+    percentOfPool: formatToPercent(userPoolState.percentOfPool),
+    unclaimedFees: formatToPercent(userPoolState.unclaimedFees),
+  };
+};
+
+export { formatPoolMetrics, formatUserPoolMetrics };

--- a/src/hooks/constants.ts
+++ b/src/hooks/constants.ts
@@ -10,6 +10,8 @@ export const L49A_TOKEN_ID = "0.0.47646195";
 
 export const L49B_TOKEN_ID = "0.0.47646196";
 
+export const A_B_PAIR_TOKEN_ID = "0.0.48143347";
+
 export const USDC_TOKEN_ID = "0.0.2276691";
 
 export const TOKEN_SYMBOL_TO_ACCOUNT_ID = new Map<string, string>([

--- a/src/hooks/useMirrorNode/services.ts
+++ b/src/hooks/useMirrorNode/services.ts
@@ -18,6 +18,15 @@ const mainnetMirrorNodeAPI = axios.create({
 
 const GREATER_THAN = "gte";
 
+/**
+ * Continues to call a mirror node endpoint to fetch subsiquent batches of data until all query data is
+ * retrieved. The Mirror Node API is limited to returning a maximum of 100 records. When there are additional
+ * records to retrieve, the Mirror Node endpoint returns a URL (under the field link.next) that can be called
+ * to retrieve the next batch of data.
+ * @param nextUrl - The URL to call to get the next batch of Mirror Node data.
+ * @param field - The response.data field to extract the returned data from.
+ * @returns The aggregate list of data gathered from the Mirror Node API calls.
+ */
 const fetchNextBatch = async (nextUrl: string, field: string, config: any = {}): Promise<any[]> => {
   const response = await testnetMirrorNodeAPI.get(nextUrl, config);
   const { links } = response.data;
@@ -28,7 +37,14 @@ const fetchNextBatch = async (nextUrl: string, field: string, config: any = {}):
   return response.data[field];
 };
 
-/** */
+/**
+ * Fetches a list of previously executed Hedera network transactions associated with an
+ * account ID up to a given point in time.
+ * @param accountId - The ID of the account to return transactions for.
+ * @param timestamp - The latest point in the past to return transactions from.
+ * @returns The list of transactions for the given account ID with a consensus timestamp greater than the
+ * provided timestamp.
+ */
 const fetchAccountTransactions = async (accountId: string, timestamp?: string) => {
   const params = {
     "account.id": accountId,
@@ -45,7 +61,10 @@ const fetchAccountTransactions = async (accountId: string, timestamp?: string) =
   return await fetchNextBatch("/api/v1/transactions", "transactions", { params });
 };
 
-// TODO: This should be replaced with a mirror call to fetch all pairs associated with the primary swap/pool contract.
+/**
+ * TODO: This is mocked data and should be replaced with a mirror node call to fetch
+ * all pairs associated with the primary swap/pool contract.
+ */
 const fetchTokenPairs = async (): Promise<TokenPair[]> => {
   return await Promise.resolve([
     {
@@ -60,7 +79,7 @@ const fetchTokenPairs = async (): Promise<TokenPair[]> => {
  * Fetches the HBAR balance and a list of token balances on the Hedera
  * network for the given account ID.
  * @param accountId - The ID of the account to return balances for.
- * @returns - The list of balances for the given account ID.
+ * @returns The list of balances for the given account ID.
  */
 const fetchAccountBalances = async (accountId: string) => {
   return await fetchNextBatch(`/api/v1/balances`, "balances", {
@@ -76,7 +95,7 @@ const fetchAccountBalances = async (accountId: string) => {
  * Fetches the list of token balances given a token ID. This represents
  * the Token supply distribution across the network
  * @param tokenId - The ID of the token to return balances for.
- * @returns - The list of balances for the given token ID.
+ * @returns The list of balances for the given token ID.
  */
 const fetchTokenBalances = async (tokenId: string) => {
   return await testnetMirrorNodeAPI.get(`/api/v1/tokens/${tokenId}/balances`, {

--- a/src/hooks/useMirrorNode/services.ts
+++ b/src/hooks/useMirrorNode/services.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { isNil } from "ramda";
-import { L49A_TOKEN_ID, L49B_TOKEN_ID } from "../constants";
+import { A_B_PAIR_TOKEN_ID, L49A_TOKEN_ID, L49B_TOKEN_ID } from "../constants";
 import { TokenPair } from "./types";
 
 const TESTNET_URL = `https://testnet.mirrornode.hedera.com`;
@@ -27,7 +27,11 @@ const fetchAccountTransactions = async (accountId: string, timestamp?: string) =
 // TODO: This should be replaced with a mirror call to fetch all pairs associated with the primary swap/pool contract.
 const fetchTokenPairs = async (): Promise<TokenPair[]> => {
   return await Promise.resolve([
-    { tokenA: { symbol: "L49A", accountId: L49A_TOKEN_ID }, tokenB: { symbol: "L49B", accountId: L49B_TOKEN_ID } },
+    {
+      pairToken: { symbol: "A-B", accountId: A_B_PAIR_TOKEN_ID },
+      tokenA: { symbol: "L49A", accountId: L49A_TOKEN_ID },
+      tokenB: { symbol: "L49B", accountId: L49B_TOKEN_ID },
+    },
   ]);
 };
 

--- a/src/hooks/useMirrorNode/services.ts
+++ b/src/hooks/useMirrorNode/services.ts
@@ -11,9 +11,10 @@ const GREATER_THAN = "gte";
 const fetchAccountTransactions = async (accountId: string, timestamp?: string) => {
   const params = {
     "account.id": accountId,
-    order: "asc",
+    order: "desc",
     transactiontype: "CRYPTOTRANSFER",
     result: "success",
+    limit: 100,
   };
   if (!isNil(timestamp)) {
     Object.assign(params, { timestamp: `${GREATER_THAN}:${timestamp}` });

--- a/src/hooks/useMirrorNode/services.ts
+++ b/src/hooks/useMirrorNode/services.ts
@@ -14,7 +14,6 @@ const fetchAccountTransactions = async (accountId: string, timestamp?: string) =
     order: "asc",
     transactiontype: "CRYPTOTRANSFER",
     result: "success",
-    type: "credit",
   };
   if (!isNil(timestamp)) {
     Object.assign(params, { timestamp: `${GREATER_THAN}:${timestamp}` });

--- a/src/hooks/useMirrorNode/types.ts
+++ b/src/hooks/useMirrorNode/types.ts
@@ -4,6 +4,7 @@ enum ActionType {
   FETCH_POOL_METRICS_FAILED = "useMirrorNode/FETCH_POOL_METRICS_FAILED",
 }
 
+/* Add Symbol */
 interface PoolState {
   name: string;
   fee: number;
@@ -28,7 +29,12 @@ interface MirrorNodeState {
   fetchAllPoolMetrics: () => Promise<void>;
 }
 
+// Only for mocking for now
 interface TokenPair {
+  pairToken: {
+    symbol: string;
+    accountId: string;
+  };
   tokenA: {
     symbol: string;
     accountId: string;

--- a/src/hooks/useMirrorNode/types.ts
+++ b/src/hooks/useMirrorNode/types.ts
@@ -1,7 +1,10 @@
 enum ActionType {
-  FETCH_POOL_METRICS_STARTED = "useMirrorNode/FETCH_POOL_METRICS_STARTED",
-  FETCH_POOL_METRICS_SUCCEEDED = "useMirrorNode/FETCH_POOL_METRICS_SUCCEEDED",
-  FETCH_POOL_METRICS_FAILED = "useMirrorNode/FETCH_POOL_METRICS_FAILED",
+  FETCH_ALL_POOL_METRICS_STARTED = "useMirrorNode/FETCH_ALL_POOL_METRICS_STARTED",
+  FETCH_ALL_METRICS_SUCCEEDED = "useMirrorNode/FETCH_ALL_POOL_METRICS_SUCCEEDED",
+  FETCH_ALL_METRICS_FAILED = "useMirrorNode/FETCH_ALL_POOL_METRICS_FAILED",
+  FETCH_USER_POOL_METRICS_STARTED = "useMirrorNode/FETCH_USER_POOL_METRICS_STARTED",
+  FETCH_USER_POOL_METRICS_SUCCEEDED = "useMirrorNode/FETCH_USER_POOL_METRICS_SUCCEEDED",
+  FETCH_USER_POOL_METRICS_FAILED = "useMirrorNode/FETCH_USER_POOL_METRICS_FAILED",
 }
 
 /* Add Symbol */
@@ -24,9 +27,12 @@ interface UserPoolState {
 interface MirrorNodeState {
   allPoolsMetrics: PoolState[];
   userPoolsMetrics: UserPoolState[];
+  poolTokenBalances: MirrorNodeTokenBalance[];
+  userTokenBalances: MirrorNodeTokenBalance[];
   status: string; // "init" | "fetching" | "success" | "error";
   errorMessage: string | null;
   fetchAllPoolMetrics: () => Promise<void>;
+  fetchUserPoolMetrics: (userAccountId: string) => Promise<void>;
 }
 
 // Only for mocking for now

--- a/src/hooks/useMirrorNode/types.ts
+++ b/src/hooks/useMirrorNode/types.ts
@@ -1,7 +1,7 @@
 enum ActionType {
-  FETCH_POOL_VOLUME_METRICS_STARTED = "useMirrorNode/FETCH_POOL_METRICS_STARTED",
-  FETCH_POOL_VOLUME_METRICS_SUCCEEDED = "useMirrorNode/FETCH_POOL_METRICS_SUCCEEDED",
-  FETCH_POOL_VOLUME_METRICS_FAILED = "useMirrorNode/FETCH_POOL_METRICS_FAILED",
+  FETCH_POOL_METRICS_STARTED = "useMirrorNode/FETCH_POOL_METRICS_STARTED",
+  FETCH_POOL_METRICS_SUCCEEDED = "useMirrorNode/FETCH_POOL_METRICS_SUCCEEDED",
+  FETCH_POOL_METRICS_FAILED = "useMirrorNode/FETCH_POOL_METRICS_FAILED",
 }
 
 interface PoolState {
@@ -25,7 +25,6 @@ interface MirrorNodeState {
   userPoolsMetrics: UserPoolState[];
   status: string; // "init" | "fetching" | "success" | "error";
   errorMessage: string | null;
-  poolVolumeMetrics: number | null;
   fetchAllPoolMetrics: () => Promise<void>;
 }
 

--- a/src/hooks/useMirrorNode/useMirrorNode.ts
+++ b/src/hooks/useMirrorNode/useMirrorNode.ts
@@ -29,7 +29,6 @@ const initialMirrorNodeState: MirrorNodeState = {
  * This should be removed after we can fetch pair tokens from the pool contract.
  * */
 const appendLiquidityTokenBalance = (poolAccountBalances: MirrorNodeAccountBalance[]) => {
-  console.log();
   const mockedLiquidityTokenBalance = {
     token_id: A_B_PAIR_TOKEN_ID,
     balance: 1000,
@@ -95,7 +94,7 @@ const useMirrorNode = create<MirrorNodeState>()(
             return calculateUserPoolMetrics({
               poolTokenBalances: get().poolTokenBalances,
               userTokenBalances,
-              tokenPair: userTokenPair,
+              userTokenPair,
             });
           });
           set(

--- a/src/hooks/useMirrorNode/useMirrorNode.ts
+++ b/src/hooks/useMirrorNode/useMirrorNode.ts
@@ -33,7 +33,7 @@ const useMirrorNode = create<MirrorNodeState>()(
         try {
           const poolAccountBalances = await fetchAccountBalances(SWAP_CONTRACT_ID);
           // THIS IS MOCKED: Need to add pair tokens to contract.
-          poolAccountBalances.data.balances
+          poolAccountBalances
             .find((poolAccountBalance: any) => poolAccountBalance.account === SWAP_CONTRACT_ID)
             ?.tokens.push({
               token_id: "0.0.48143347",
@@ -47,9 +47,9 @@ const useMirrorNode = create<MirrorNodeState>()(
           const allPoolsMetrics = poolTokenPairs.map((tokenPair) => {
             return calculatePoolMetrics({
               poolAccountId: SWAP_CONTRACT_ID,
-              poolAccountBalances: poolAccountBalances.data.balances,
-              last24Transactions: last24Transactions.data.transactions,
-              last7DTransactions: last7DTransactions.data.transactions,
+              poolAccountBalances,
+              last24Transactions,
+              last7DTransactions,
               tokenPair,
             });
           });
@@ -58,7 +58,7 @@ const useMirrorNode = create<MirrorNodeState>()(
           const userAccountBalances = await fetchAccountBalances(userAccountId);
           // return if user has pair token in walet
           const userLPTokensList = poolTokenPairs.filter((poolTokenPair) => {
-            const userTokenBalances = userAccountBalances.data.balances.find(
+            const userTokenBalances = userAccountBalances.find(
               (userAccountBalance: any) => userAccountBalance.account === userAccountId // wallet address
             )?.tokens;
             return userTokenBalances.some(
@@ -68,8 +68,8 @@ const useMirrorNode = create<MirrorNodeState>()(
           const userPoolsMetrics = userLPTokensList.map((tokenPair) => {
             return calculateUserPoolMetrics({
               allPoolsMetrics,
-              poolAccountBalances: poolAccountBalances.data.balances,
-              userAccountBalances: userAccountBalances.data.balances,
+              poolAccountBalances,
+              userAccountBalances,
               tokenPair,
             });
           });

--- a/src/hooks/useMirrorNode/useMirrorNode.ts
+++ b/src/hooks/useMirrorNode/useMirrorNode.ts
@@ -12,6 +12,7 @@ import {
   getTokenBalances,
   getTransactionsFromLast24Hours,
 } from "./utils";
+import { isNil } from "ramda";
 
 const initialMirrorNodeState: MirrorNodeState = {
   allPoolsMetrics: [],
@@ -81,6 +82,9 @@ const useMirrorNode = create<MirrorNodeState>()(
       fetchUserPoolMetrics: async (userAccountId: string) => {
         set({ status: "fetching" }, false, ActionType.FETCH_USER_POOL_METRICS_STARTED);
         try {
+          if (isNil(userAccountId)) {
+            throw Error("User Account ID must be defined.");
+          }
           const userAccountBalances = await fetchAccountBalances(userAccountId);
           const poolTokenPairs = await fetchTokenPairs();
           const userTokenBalances = getTokenBalances(userAccountBalances, userAccountId);

--- a/src/hooks/useMirrorNode/useMirrorNode.ts
+++ b/src/hooks/useMirrorNode/useMirrorNode.ts
@@ -5,7 +5,7 @@ import { fetchAccountBalances, fetchAccountTransactions, fetchTokenPairs } from 
 import { getErrorMessage } from "../utils";
 import { ActionType, MirrorNodeState } from "./types";
 import { SWAP_CONTRACT_ID } from "../constants";
-import { calculatePoolMetrics, getTimestamp24HoursAgo, getTimestamp7DaysAgo } from "./utils";
+import { calculatePoolMetrics, calculateUserPoolMetrics, getTimestamp24HoursAgo, getTimestamp7DaysAgo } from "./utils";
 
 const initialMirrorNodeState: MirrorNodeState = {
   allPoolsMetrics: [],
@@ -28,25 +28,52 @@ const useMirrorNode = create<MirrorNodeState>()(
       userPoolsMetrics: [],
       status: "init",
       errorMessage: null,
-      fetchAllPoolMetrics: async () => {
+      fetchAllPoolMetrics: async (/*need user Token Pairs & LP balances*/) => {
         set({ status: "fetching" }, false, ActionType.FETCH_POOL_METRICS_STARTED);
         try {
-          const accountBalances = await fetchAccountBalances(SWAP_CONTRACT_ID);
+          const poolAccountBalances = await fetchAccountBalances(SWAP_CONTRACT_ID);
+          // THIS IS MOCKED: Need to add pair tokens to contract.
+          poolAccountBalances.data.balances
+            .find((poolAccountBalance: any) => poolAccountBalance.account === SWAP_CONTRACT_ID)
+            ?.tokens.push({
+              token_id: "0.0.48143347",
+              balance: 1000,
+            });
           const timestamp24HoursAgo = getTimestamp24HoursAgo();
           const timestamp7DaysAgo = getTimestamp7DaysAgo();
           const last24Transactions = await fetchAccountTransactions(SWAP_CONTRACT_ID, timestamp24HoursAgo);
           const last7DTransactions = await fetchAccountTransactions(SWAP_CONTRACT_ID, timestamp7DaysAgo);
-          const tokenPairs = await fetchTokenPairs();
-          const allPoolsMetrics = tokenPairs.map((tokenPair) => {
+          const poolTokenPairs = await fetchTokenPairs();
+          const allPoolsMetrics = poolTokenPairs.map((tokenPair) => {
             return calculatePoolMetrics({
               poolAccountId: SWAP_CONTRACT_ID,
-              accountBalances: accountBalances.data.balances,
+              poolAccountBalances: poolAccountBalances.data.balances,
               last24Transactions: last24Transactions.data.transactions,
               last7DTransactions: last7DTransactions.data.transactions,
               tokenPair,
             });
           });
-          set({ status: "success", allPoolsMetrics }, false, ActionType.FETCH_POOL_METRICS_SUCCEEDED);
+
+          const userAccountId = "0.0.34728121";
+          const userAccountBalances = await fetchAccountBalances(userAccountId);
+          // return if user has pair token in walet
+          const userLPTokensList = poolTokenPairs.filter((poolTokenPair) => {
+            const userTokenBalances = userAccountBalances.data.balances.find(
+              (userAccountBalance: any) => userAccountBalance.account === userAccountId // wallet address
+            )?.tokens;
+            return userTokenBalances.some(
+              (userTokenBalance: any) => userTokenBalance.token_id === poolTokenPair.pairToken.accountId
+            );
+          });
+          const userPoolsMetrics = userLPTokensList.map((tokenPair) => {
+            return calculateUserPoolMetrics({
+              allPoolsMetrics,
+              poolAccountBalances: poolAccountBalances.data.balances,
+              userAccountBalances: userAccountBalances.data.balances,
+              tokenPair,
+            });
+          });
+          set({ status: "success", allPoolsMetrics, userPoolsMetrics }, false, ActionType.FETCH_POOL_METRICS_SUCCEEDED);
         } catch (error) {
           const errorMessage = getErrorMessage(error);
           set({ status: "error", errorMessage }, false, ActionType.FETCH_POOL_METRICS_STARTED);

--- a/src/hooks/useMirrorNode/useMirrorNode.ts
+++ b/src/hooks/useMirrorNode/useMirrorNode.ts
@@ -5,14 +5,13 @@ import { fetchAccountBalances, fetchAccountTransactions, fetchTokenPairs } from 
 import { getErrorMessage } from "../utils";
 import { ActionType, MirrorNodeState } from "./types";
 import { SWAP_CONTRACT_ID } from "../constants";
-import { calculatePoolVolumeMetrics, getTimestamp24HoursAgo, getTimestamp7DaysAgo } from "./utils";
+import { calculatePoolMetrics, getTimestamp24HoursAgo, getTimestamp7DaysAgo } from "./utils";
 
 const initialMirrorNodeState: MirrorNodeState = {
   allPoolsMetrics: [],
   userPoolsMetrics: [],
   status: "init",
   errorMessage: null,
-  poolVolumeMetrics: null,
   fetchAllPoolMetrics: () => Promise.resolve(),
 };
 
@@ -29,9 +28,8 @@ const useMirrorNode = create<MirrorNodeState>()(
       userPoolsMetrics: [],
       status: "init",
       errorMessage: null,
-      poolVolumeMetrics: null,
       fetchAllPoolMetrics: async () => {
-        set({ status: "fetching" }, false, ActionType.FETCH_POOL_VOLUME_METRICS_STARTED);
+        set({ status: "fetching" }, false, ActionType.FETCH_POOL_METRICS_STARTED);
         try {
           const accountBalances = await fetchAccountBalances(SWAP_CONTRACT_ID);
           const timestamp24HoursAgo = getTimestamp24HoursAgo();
@@ -40,17 +38,17 @@ const useMirrorNode = create<MirrorNodeState>()(
           const last7DTransactions = await fetchAccountTransactions(SWAP_CONTRACT_ID, timestamp7DaysAgo);
           const tokenPairs = await fetchTokenPairs();
           const allPoolsMetrics = tokenPairs.map((tokenPair) => {
-            return calculatePoolVolumeMetrics({
+            return calculatePoolMetrics({
               accountBalances: accountBalances.data.balances,
               last24Transactions: last24Transactions.data.transactions,
               last7DTransactions: last7DTransactions.data.transactions,
               tokenPair,
             });
           });
-          set({ status: "success", allPoolsMetrics }, false, ActionType.FETCH_POOL_VOLUME_METRICS_SUCCEEDED);
+          set({ status: "success", allPoolsMetrics }, false, ActionType.FETCH_POOL_METRICS_SUCCEEDED);
         } catch (error) {
           const errorMessage = getErrorMessage(error);
-          set({ status: "error", errorMessage }, false, ActionType.FETCH_POOL_VOLUME_METRICS_STARTED);
+          set({ status: "error", errorMessage }, false, ActionType.FETCH_POOL_METRICS_STARTED);
         }
       },
     }))

--- a/src/hooks/useMirrorNode/useMirrorNode.ts
+++ b/src/hooks/useMirrorNode/useMirrorNode.ts
@@ -39,6 +39,7 @@ const useMirrorNode = create<MirrorNodeState>()(
           const tokenPairs = await fetchTokenPairs();
           const allPoolsMetrics = tokenPairs.map((tokenPair) => {
             return calculatePoolMetrics({
+              poolAccountId: SWAP_CONTRACT_ID,
               accountBalances: accountBalances.data.balances,
               last24Transactions: last24Transactions.data.transactions,
               last7DTransactions: last7DTransactions.data.transactions,

--- a/src/hooks/useMirrorNode/utils/poolMetrics.ts
+++ b/src/hooks/useMirrorNode/utils/poolMetrics.ts
@@ -47,8 +47,8 @@ const calculateVolume = (tokenAccountId: string, contractTransactions: MirrorNod
   const tokenTransfers = contractTransactions.flatMap((contractTransaction) => contractTransaction.token_transfers);
   const volume = tokenTransfers.reduce((tokenTransactionVolume: number, tokenTransfer: MirrorNodeTokenTransfer) => {
     const { token_id, amount } = tokenTransfer;
-    if (token_id === tokenAccountId && amount > 0) {
-      return tokenTransactionVolume + amount;
+    if (token_id === tokenAccountId) {
+      return tokenTransactionVolume + Math.abs(amount);
     }
     return tokenTransactionVolume;
   }, 0);
@@ -67,7 +67,7 @@ interface CalculatePoolMetricsParams {
   tokenPair: TokenPair;
 }
 
-export const calculatePoolVolumeMetrics = ({
+const calculatePoolMetrics = ({
   accountBalances,
   last24Transactions,
   last7DTransactions,
@@ -86,3 +86,5 @@ export const calculatePoolVolumeMetrics = ({
     past7daysVolume: calculateVolume(tokenA.accountId, last7DTransactions),
   };
 };
+
+export { calculatePoolMetrics };

--- a/src/hooks/useMirrorNode/utils/poolMetrics.ts
+++ b/src/hooks/useMirrorNode/utils/poolMetrics.ts
@@ -54,8 +54,8 @@ const calculateVolume = ({ poolAccountId, tokenAccountId, accountTransactions }:
   const allTokenTransfers = accountTransactions.flatMap((accountTransaction) => accountTransaction.token_transfers);
   const volume = allTokenTransfers.reduce((tokenTransactionVolume: number, tokenTransfer: MirrorNodeTokenTransfer) => {
     const { token_id, account, amount } = tokenTransfer;
-    if (account === poolAccountId && token_id === tokenAccountId) {
-      return tokenTransactionVolume + Math.abs(amount);
+    if (account === poolAccountId && token_id === tokenAccountId && amount >= 0) {
+      return tokenTransactionVolume + amount;
     }
     return tokenTransactionVolume;
   }, 0);

--- a/src/hooks/useMirrorNode/utils/poolMetrics.ts
+++ b/src/hooks/useMirrorNode/utils/poolMetrics.ts
@@ -54,8 +54,8 @@ const calculateVolume = ({ poolAccountId, tokenAccountId, accountTransactions }:
   const allTokenTransfers = accountTransactions.flatMap((accountTransaction) => accountTransaction.token_transfers);
   const volume = allTokenTransfers.reduce((tokenTransactionVolume: number, tokenTransfer: MirrorNodeTokenTransfer) => {
     const { token_id, account, amount } = tokenTransfer;
-    if (account === poolAccountId && token_id === tokenAccountId && amount >= 0) {
-      return tokenTransactionVolume + amount;
+    if (account === poolAccountId && token_id === tokenAccountId) {
+      return tokenTransactionVolume + Math.abs(amount);
     }
     return tokenTransactionVolume;
   }, 0);


### PR DESCRIPTION
**Description**:

- User pool metrics are fetched, formatted, and displayed in the Pool UI table.
- All pool metrics now correctly aggregate token **credit and debit** transactions in volume calculations.
- The Mirror Node API limits returned data to 100 records. I've incorporated logic that will make subsequent calls to the Mirror Node API to get the full batch of records. A function will fetch and aggregate batches of 100 records until the Mirror Node API no longer returns a **link.next** URL, i.e. all records for the query have been accounted for.
- Pool and User Pool balances are saved in MirrorNodeState.

![Screen Shot 2022-10-10 at 9 01 58 PM](https://user-images.githubusercontent.com/54907098/194974738-4f06ff5e-84b5-43d2-b092-ab6e5b11e6e3.png)

![Screen Shot 2022-10-10 at 9 02 32 PM](https://user-images.githubusercontent.com/54907098/194974776-03625171-93a2-4e63-bd05-c8427d201e01.png)

