### PR TITLE
feat: New Token Proposal Wallet Signing Flow (Success and Failure)

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,13 +12,4 @@ module.exports = {
     builder: "@storybook/builder-webpack5",
   },
   features: { emotionAlias: false },
-  webpackFinal: async (config) => {
-    config.module.rules.push({
-      test: /\.mjs$/,
-      include: /node_modules/,
-      type: "javascript/auto",
-    });
-
-    return config;
-  },
 };

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -11,4 +11,14 @@ module.exports = {
   core: {
     builder: "@storybook/builder-webpack5",
   },
+  features: { emotionAlias: false },
+  webpackFinal: async (config) => {
+    config.module.rules.push({
+      test: /\.mjs$/,
+      include: /node_modules/,
+      type: "javascript/auto",
+    });
+
+    return config;
+  },
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,15 +1,18 @@
-import { themes } from "@storybook/theming";
+import { DEXTheme } from "../src/dex-ui/styles";
 import HederaDeFiTheme from "./HederaDeFiTheme";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   docs: {
-    theme: HederaDeFiTheme
+    theme: HederaDeFiTheme,
+  },
+  chakra: {
+    theme: DEXTheme,
   },
   controls: {
     matchers: {
       color: /(background|color)$/i,
-      date: /Date$/
-    }
-  }
+      date: /Date$/,
+    },
+  },
 };

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 <h1>
   Hedera DEX UI Accelerator 
 </h1>
+<p>Live App: <b><a href="https://defi-ui.hedera.com">defi-dex</a></b></p>
 <p>Status: <b>POC</b></p>
 <p align="center" style="font-size: 1.2rem;">A DEX (Decentralized Exchange) UI accelerator that operates on the Hedera network. The DEX UI utilizes React primitives from the <a href="https://github.com/hashgraph/hedera-accelerator-defi-dex-ui-components">hedera-accelerator-defi-dex-ui-components</a> UI component library.</p>
 

--- a/src/dex-ui-components/SwapTokens/SwapTokens.tsx
+++ b/src/dex-ui-components/SwapTokens/SwapTokens.tsx
@@ -1,18 +1,7 @@
 import { ChangeEvent, MouseEvent, useCallback, useEffect, useState } from "react";
 import { useImmerReducer } from "use-immer";
-import {
-  ChakraProvider,
-  Box,
-  Heading,
-  Flex,
-  Spacer,
-  Text,
-  Collapse,
-  TagCloseButton,
-  Link,
-  Tag,
-} from "@chakra-ui/react";
-import { SettingsIcon, UpDownIcon, ExternalLinkIcon } from "@chakra-ui/icons";
+import { ChakraProvider, Box, Heading, Flex, Spacer, Text, Collapse } from "@chakra-ui/react";
+import { SettingsIcon, UpDownIcon } from "@chakra-ui/icons";
 import { HashConnectTypes } from "hashconnect";
 import { DEXTheme } from "../../dex-ui/styles";
 import { swapReducer, initialSwapState, initSwapReducer } from "./reducers";

--- a/src/dex-ui-components/SwapTokens/SwapTokens.tsx
+++ b/src/dex-ui-components/SwapTokens/SwapTokens.tsx
@@ -32,7 +32,15 @@ import {
   setSlippageSetting,
   setTransactionDeadlineSetting,
 } from "./actions/swapActions";
-import { Button, IconButton, MetricLabel, SwapSettingsInput, SwapSettingsInputProps } from "../base";
+import {
+  Button,
+  IconButton,
+  MetricLabel,
+  NotficationTypes,
+  Notification,
+  SwapSettingsInput,
+  SwapSettingsInputProps,
+} from "../base";
 import { TokenInput } from "../TokenInput/TokenInput";
 import { formulaTypes } from "./types";
 import { halfOf } from "./utils";
@@ -41,6 +49,7 @@ import { SwapConfirmation, SwapConfirmationStep } from "./SwapConfirmation";
 import { Networks, WalletConnectionStatus } from "../../dex-ui/store/walletSlice";
 import { TransactionState } from "../../dex-ui/store/swapSlice";
 import { AppFeatures } from "../../dex-ui/store/appSlice";
+import { createHashScanLink } from "../../dex-ui/utils";
 
 export interface SwapTokensProps {
   title: string;
@@ -368,23 +377,13 @@ const SwapTokens = (props: SwapTokensProps) => {
     });
   }, [localSwapState, swapState]);
 
-  const getHashScanLink = useCallback(() => {
-    const transactionId = transactionState.successPayload?.transactionId.toString();
-    const urlFormattedTimestamp = transactionId?.split("@")[1].replace(".", "-");
-    const formattedTransactionId = `${transactionId?.split("@")[0]}-${urlFormattedTimestamp}`;
-    // format: https://hashscan.io/#/testnet/transaction/0.0.34744739-1665448985-817445871
-    // TODO: set testnet/mainnet based on network
-    return `https://hashscan.io/#/testnet/transaction/${formattedTransactionId}`;
-  }, [transactionState]);
-
   return (
     <ChakraProvider theme={DEXTheme}>
       <Box
         data-testid="swap-component"
         bg="white"
         borderRadius="15px"
-        width="100%"
-        minWidth="496px"
+        width="400px"
         padding="0.5rem 1rem 1rem 1rem"
         boxShadow="0px 4px 20px rgba(0, 0, 0, 0.15)"
       >
@@ -392,30 +391,25 @@ const SwapTokens = (props: SwapTokensProps) => {
         !transactionState.errorMessage &&
         !transactionState.transactionWaitingToBeSigned &&
         localSwapState.showSuccessMessage ? (
-          <Tag width={"100%"} padding={"8px"} marginBottom={"8px"} backgroundColor={"#00e64d33"}>
-            <Flex width={"100%"} flexDirection={"column"}>
-              <Text color={"#000000"}>
-                {`Swapped ${localSwapState.tokenToTradeAmount} ${localSwapState.tokenToTradeSymbol}
-                 for ${localSwapState.tokenToReceiveAmount} ${localSwapState.tokenToReceiveSymbol}`}
-              </Text>
-              <Link
-                width={"fit-content"}
-                display={"flex"}
-                alignItems={"center"}
-                color={"#0180FF"}
-                href={getHashScanLink()}
-                isExternal
-              >
-                <Text textDecoration={"underline"}>View in HashScan</Text> <ExternalLinkIcon />
-              </Link>
-            </Flex>
-            <TagCloseButton
-              color={"#000000"}
-              onClick={() => setLocalSwapState({ ...localSwapState, showSuccessMessage: false })}
+          <>
+            <Spacer margin="0.25rem 0rem" />
+            <Notification
+              type={NotficationTypes.SUCCESS}
+              textStyle={"b3"}
+              message={`Swapped ${Number(localSwapState.tokenToTradeAmount.toFixed(6))} ${
+                localSwapState.tokenToTradeSymbol
+              }
+          for ${Number(localSwapState.tokenToReceiveAmount.toFixed(6))} ${localSwapState.tokenToReceiveSymbol}`}
+              isLinkShown={true}
+              linkText="View in HashScan"
+              linkRef={createHashScanLink(transactionState.successPayload?.transactionId.toString())}
+              isCloseButtonShown={true}
+              handleClickClose={() => setLocalSwapState({ ...localSwapState, showSuccessMessage: false })}
             />
-          </Tag>
+            <Spacer margin="0.5rem 0rem" />
+          </>
         ) : (
-          ""
+          <></>
         )}
         <Flex alignItems={"center"} marginBottom={"8px"}>
           <Heading as="h4" fontWeight="500" size="lg">

--- a/src/dex-ui-components/base/Button/styles/ButtonStyles.ts
+++ b/src/dex-ui-components/base/Button/styles/ButtonStyles.ts
@@ -19,6 +19,14 @@ export const ButtonStyles: ComponentStyleConfig = {
     primary: {
       ...primary,
     },
+    secondary: {
+      bg: "white",
+      height: "44px",
+      border: "1px solid #E7E9EB",
+      boxShadow: "0px 0px 10px rgba(0, 0, 0, 0.05)",
+      borderRadius: "8px",
+    },
+    cancel: {},
     "new-proposal": {
       ...primary,
       minWidth: "250px",

--- a/src/dex-ui-components/base/Dialogs/LoadingDialog.tsx
+++ b/src/dex-ui-components/base/Dialogs/LoadingDialog.tsx
@@ -1,5 +1,5 @@
 import { RepeatIcon } from "@chakra-ui/icons";
-import { Button, Modal, ModalBody, ModalContent, ModalOverlay, Text } from "@chakra-ui/react";
+import { Button, Modal, ModalBody, ModalContent, ModalOverlay, Spacer, Text } from "@chakra-ui/react";
 
 interface ButtonConfig {
   text: string;
@@ -26,25 +26,34 @@ const LoadingDialog = (props: LoadingDialogProps) => {
         onClose={onClose ? onClose : () => null}
       >
         <ModalOverlay />
-        <ModalContent width={width ? `${width}px` : "317px"}>
+        <ModalContent
+          width={width ? `${width}px` : "317px"}
+          boxShadow="0px 4px 15px rgba(0, 0, 0, 0.15)"
+          borderRadius="5px"
+        >
           <ModalBody
             width={"100%"}
             display={"flex"}
             flexDirection={"column"}
             justifyContent={"center"}
             alignItems={"center"}
-            padding={"24px 8px"}
+            padding={"1.5rem 0.75rem 0rem"}
           >
-            <>{icon ? icon : <RepeatIcon h={10} w={10} />}</>
-            <Text marginTop={"24px"} fontSize={"18px"} lineHeight={"22px"} textAlign="center">
+            <>{icon ? icon : <RepeatIcon color="#31A9BD" h={10} w={10} />}</>
+            <Spacer margin="12px" />
+            <Text textStyle="b1" textAlign="center">
               {message}
             </Text>
+            <Spacer margin="8px" />
             {buttonConfig ? (
-              <Button marginTop={"16px"} onClick={buttonConfig.onClick}>
-                {buttonConfig.text}
-              </Button>
+              <>
+                <Button variant="primary" width="256px" onClick={buttonConfig.onClick}>
+                  {buttonConfig.text}
+                </Button>
+                <Spacer margin="8px" />
+              </>
             ) : (
-              ""
+              <></>
             )}
           </ModalBody>
         </ModalContent>

--- a/src/dex-ui-components/base/Dialogs/LoadingDialog.tsx
+++ b/src/dex-ui-components/base/Dialogs/LoadingDialog.tsx
@@ -1,5 +1,4 @@
-import { RepeatIcon } from "@chakra-ui/icons";
-import { Button, Modal, ModalBody, ModalContent, ModalOverlay, Spacer, Text } from "@chakra-ui/react";
+import { Button, Modal, ModalBody, ModalContent, ModalOverlay, Spacer, Spinner, Text } from "@chakra-ui/react";
 
 interface ButtonConfig {
   text: string;
@@ -14,6 +13,9 @@ interface LoadingDialogProps {
   buttonConfig?: ButtonConfig;
 }
 
+/**
+ * TODO: Add TSDocs
+ */
 const LoadingDialog = (props: LoadingDialogProps) => {
   const { message, isOpen, onClose, width, icon, buttonConfig } = props;
   return (
@@ -39,7 +41,13 @@ const LoadingDialog = (props: LoadingDialogProps) => {
             alignItems={"center"}
             padding={"1.5rem 0.75rem 0rem"}
           >
-            <>{icon ? icon : <RepeatIcon color="#31A9BD" h={10} w={10} />}</>
+            <>
+              {icon ? (
+                icon
+              ) : (
+                <Spinner color="#31A9BD" thickness="4px" speed="0.65s" emptyColor="gray.200" h={10} w={10} />
+              )}
+            </>
             <Spacer margin="12px" />
             <Text textStyle="b1" textAlign="center">
               {message}

--- a/src/dex-ui-components/base/Inputs/styles/InputStyles.ts
+++ b/src/dex-ui-components/base/Inputs/styles/InputStyles.ts
@@ -1,0 +1,29 @@
+import { ComponentStyleConfig } from "@chakra-ui/react";
+
+/**
+ * Base Chakra UI styles and variants for the Hedera DEX Input components
+ * and sub-component parts.
+ */
+export const InputStyles: ComponentStyleConfig = {
+  baseStyle: {},
+  sizes: {},
+  variants: {
+    "form-input": {
+      field: {
+        bg: "#FFFFFF",
+        border: "1px solid #F2F2F4",
+        boxShadow: "0px 4px 10px rgba(0, 0, 0, 0.1)",
+        borderRadius: "8px",
+        padding: "16px",
+        height: "52px",
+        "::placeholder": {
+          fontSize: "16px",
+          lineHeight: "19px",
+          fontWeight: "400",
+          color: "#C4C4C4",
+        },
+      },
+    },
+  },
+  defaultProps: {},
+};

--- a/src/dex-ui-components/base/Inputs/styles/index.ts
+++ b/src/dex-ui-components/base/Inputs/styles/index.ts
@@ -1,1 +1,2 @@
 export * from "./NumberInputStyles";
+export * from "./InputStyles";

--- a/src/dex-ui-components/base/Notification/Notification.tsx
+++ b/src/dex-ui-components/base/Notification/Notification.tsx
@@ -1,5 +1,5 @@
 import { ExternalLinkIcon } from "@chakra-ui/icons";
-import { Tag, Text, Flex, Link, TagCloseButton, Box, HStack } from "@chakra-ui/react";
+import { Tag, Text, Flex, Link, TagCloseButton, Box } from "@chakra-ui/react";
 import { useCallback } from "react";
 
 export enum NotficationTypes {
@@ -19,6 +19,10 @@ interface NotificationProps {
   handleClickClose?: () => void;
 }
 
+/**
+ * A component used to communicate to a user a state that affects a system, feature or page.
+ * TODO: Add TSDocs
+ */
 export const Notification = (props: NotificationProps) => {
   const {
     type = NotficationTypes.WARNING,
@@ -43,6 +47,7 @@ export const Notification = (props: NotificationProps) => {
     }
   }, [type]);
 
+  /** The Alert component is most likely prefered over using Tag for this components. */
   return (
     <Tag width="100%" padding="0.5rem" backgroundColor={getNotificationColors()?.bg} borderRadius="5px">
       <Flex flexWrap="wrap" width="100%">

--- a/src/dex-ui-components/base/Notification/Notification.tsx
+++ b/src/dex-ui-components/base/Notification/Notification.tsx
@@ -1,0 +1,70 @@
+import { ExternalLinkIcon } from "@chakra-ui/icons";
+import { Tag, Text, Flex, Link, TagCloseButton, Box, HStack } from "@chakra-ui/react";
+import { useCallback } from "react";
+
+export enum NotficationTypes {
+  SUCCESS = "success",
+  WARNING = "warning",
+  ERROR = "error",
+}
+
+interface NotificationProps {
+  type: NotficationTypes;
+  textStyle?: string;
+  message: string;
+  isLinkShown?: boolean;
+  linkText?: string;
+  linkRef?: string;
+  isCloseButtonShown?: boolean;
+  handleClickClose?: () => void;
+}
+
+export const Notification = (props: NotificationProps) => {
+  const {
+    type = NotficationTypes.WARNING,
+    textStyle = "b2",
+    message,
+    isLinkShown = false,
+    linkText,
+    linkRef,
+    isCloseButtonShown = false,
+    handleClickClose,
+  } = props;
+
+  const getNotificationColors = useCallback(() => {
+    if (type === NotficationTypes.SUCCESS) {
+      return { bg: "#C4F2D3", text: "#23714B" };
+    }
+    if (type === NotficationTypes.WARNING) {
+      return { bg: "#FFF3CB", text: "#9F6000" };
+    }
+    if (type === NotficationTypes.ERROR) {
+      return { bg: "#FFD1D1", text: "#FF1A1A" };
+    }
+  }, [type]);
+
+  return (
+    <Tag width="100%" padding="0.5rem" backgroundColor={getNotificationColors()?.bg} borderRadius="5px">
+      <Flex flexWrap="wrap" width="100%">
+        <Text textStyle={textStyle} color={getNotificationColors()?.text}>
+          {message} &nbsp;
+        </Text>
+        {isLinkShown ? (
+          <Link width="fit-content" display="flex" alignItems="center" color="#0180FF" href={linkRef} isExternal>
+            <Text textDecoration="underline">{linkText}</Text>
+            <ExternalLinkIcon margin="0rem 0.125rem" />
+          </Link>
+        ) : (
+          <></>
+        )}
+      </Flex>
+      {isCloseButtonShown ? (
+        <Box flex="1">
+          <TagCloseButton float="right" color={getNotificationColors()?.text} onClick={handleClickClose} />
+        </Box>
+      ) : (
+        <></>
+      )}
+    </Tag>
+  );
+};

--- a/src/dex-ui-components/base/Notification/index.ts
+++ b/src/dex-ui-components/base/Notification/index.ts
@@ -1,0 +1,1 @@
+export * from "./Notification";

--- a/src/dex-ui-components/base/index.ts
+++ b/src/dex-ui-components/base/index.ts
@@ -6,3 +6,4 @@ export * from "./Dialogs";
 export * from "./Labels";
 export * from "./Card";
 export * from "./RadioCard";
+export * from "./Notification";

--- a/src/dex-ui-components/stories/Button.stories.tsx
+++ b/src/dex-ui-components/stories/Button.stories.tsx
@@ -15,4 +15,13 @@ export default {
   },
 } as ComponentMeta<typeof Button>;
 
-export const Basic: ComponentStory<typeof Button> = (args) => <Button {...args}>Connect</Button>;
+const Template: ComponentStory<typeof Button> = (args: any) => <Button {...args}>Button</Button>;
+
+export const Primary: ComponentStory<typeof Button> = Template.bind({});
+Primary.args = { variant: "primary" };
+
+export const Secondary: ComponentStory<typeof Button> = Template.bind({});
+Secondary.args = { variant: "Secondary" };
+
+export const Tertiary: ComponentStory<typeof Button> = Template.bind({});
+Tertiary.args = { variant: "tertiary" };

--- a/src/dex-ui-components/stories/Notification.stories.mdx
+++ b/src/dex-ui-components/stories/Notification.stories.mdx
@@ -1,0 +1,20 @@
+<!-- Notification.stories.mdx -->
+
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+
+import { Notification } from "..";
+
+<Meta title="Notification" component={Notification} />
+
+export const Template = (args) => <Notification {...args}>Button</Notification>;
+
+# Button
+
+With `MDX`, we can define a story for `Notification` right in the middle of our
+Markdown documentation.
+
+<Canvas>
+  <Story name="notification">
+    <Notification />
+  </Story>
+</Canvas>

--- a/src/dex-ui-components/stories/Notification.stories.mdx
+++ b/src/dex-ui-components/stories/Notification.stories.mdx
@@ -8,7 +8,7 @@ import { Notification } from "..";
 
 export const Template = (args) => <Notification {...args}>Button</Notification>;
 
-# Button
+# Notification
 
 With `MDX`, we can define a story for `Notification` right in the middle of our
 Markdown documentation.

--- a/src/dex-ui-components/stories/Notification.stories.tsx
+++ b/src/dex-ui-components/stories/Notification.stories.tsx
@@ -1,0 +1,41 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Notification, NotficationTypes } from "..";
+
+export default {
+  /* 👇 The title prop is optional.
+   * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
+   * to learn how to generate automatic titles
+   */
+  title: "Notification",
+  component: Notification,
+  parameters: {
+    docs: {
+      page: "Notification",
+    },
+  },
+} as ComponentMeta<typeof Notification>;
+
+const Template: ComponentStory<typeof Notification> = (args: any) => <Notification {...args} />;
+
+export const Success: ComponentStory<typeof Notification> = Template.bind({});
+Success.args = {
+  type: NotficationTypes.SUCCESS,
+  message: "Swapped 10.0 HBAR for 0.659409 USDT",
+  isLinkShown: true,
+  linkText: "View in HashScan",
+  linkRef: "https://hashscan.io/testnet/dashboard",
+  isCloseButtonShown: true,
+};
+
+export const Warning: ComponentStory<typeof Notification> = Template.bind({});
+Warning.args = {
+  type: NotficationTypes.WARNING,
+  message: "You’ll need to connect a wallet before you can view balances and swap tokens.",
+  isCloseButtonShown: true,
+};
+
+export const Error: ComponentStory<typeof Notification> = Template.bind({});
+Error.args = {
+  type: NotficationTypes.ERROR,
+  message: "Not enough USDT available to swap for 10 HBAR.",
+};

--- a/src/dex-ui/DEX.tsx
+++ b/src/dex-ui/DEX.tsx
@@ -4,6 +4,7 @@ import { TopMenuBar } from "./layouts/TopMenuBar";
 import { DEXTheme } from "./styles";
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import { useWalletConnection } from "./hooks";
+import { ScrollToTop } from "./utils";
 
 const menuOptions = ["Swap", "Pools", "Governance"];
 
@@ -13,22 +14,24 @@ const DEX = () => {
     <ChakraProvider theme={DEXTheme}>
       <Container color="black" w="100%" maxHeight="100%" maxWidth="100%" bg="#FFFFFF" marginBottom="5rem" centerContent>
         <Router>
-          <TopMenuBar menuOptions={menuOptions}></TopMenuBar>
-          <Flex width="66rem" justifyContent="center">
-            <Routes>
-              <Route path="/" element={<Navigate to="/swap" />} />
-              <Route path="/swap" element={<Swap />} />
-              <Route path="/pools" element={<Pools />} />
-              <Route path="/pools/add-liquidity" element={<AddLiquidity />} />
-              <Route path="/pools/withdraw" element={<Withdraw />} />
-              <Route path="/governance" element={<Governance />} />
-              <Route path="/governance/select-proposal-type" element={<SelectProposalType />} />
-              <Route path="/governance/select-proposal-type/new-token" element={<CreateProposal />} />
-              <Route path="/governance/select-proposal-type/text" element={<CreateProposal />} />
-              <Route path="/governance/select-proposal-type/token-transfer" element={<CreateProposal />} />
-              <Route path="/governance/select-proposal-type/contract-upgrade" element={<CreateProposal />} />
-            </Routes>
-          </Flex>
+          <ScrollToTop>
+            <TopMenuBar menuOptions={menuOptions}></TopMenuBar>
+            <Flex width="66rem" justifyContent="center">
+              <Routes>
+                <Route path="/" element={<Navigate to="/swap" />} />
+                <Route path="/swap" element={<Swap />} />
+                <Route path="/pools" element={<Pools />} />
+                <Route path="/pools/add-liquidity" element={<AddLiquidity />} />
+                <Route path="/pools/withdraw" element={<Withdraw />} />
+                <Route path="/governance" element={<Governance />} />
+                <Route path="/governance/select-proposal-type" element={<SelectProposalType />} />
+                <Route path="/governance/select-proposal-type/new-token" element={<CreateProposal />} />
+                <Route path="/governance/select-proposal-type/text" element={<CreateProposal />} />
+                <Route path="/governance/select-proposal-type/token-transfer" element={<CreateProposal />} />
+                <Route path="/governance/select-proposal-type/contract-upgrade" element={<CreateProposal />} />
+              </Routes>
+            </Flex>
+          </ScrollToTop>
         </Router>
       </Container>
     </ChakraProvider>

--- a/src/dex-ui/hooks/useGovernanceData.tsx
+++ b/src/dex-ui/hooks/useGovernanceData.tsx
@@ -13,7 +13,7 @@ export const useGovernanceData = () => {
   }, [fetchProposals]);
 
   /**
-   * Fetches all pool data on first load and change of wallet account ID.
+   * Fetches all governance data on first load.
    */
   useEffect(() => {
     fetchGovernanceDataOnLoad();

--- a/src/dex-ui/hooks/useGovernanceData.tsx
+++ b/src/dex-ui/hooks/useGovernanceData.tsx
@@ -1,0 +1,21 @@
+import { useCallback, useEffect } from "react";
+import { useDexContext } from ".";
+
+/**
+ * Fetches governance data on page load.
+ */
+export const useGovernanceData = () => {
+  const { governance } = useDexContext(({ governance }) => ({ governance }));
+  const { fetchProposals } = governance;
+
+  const fetchGovernanceDataOnLoad = useCallback(async () => {
+    await fetchProposals();
+  }, [fetchProposals]);
+
+  /**
+   * Fetches all pool data on first load and change of wallet account ID.
+   */
+  useEffect(() => {
+    fetchGovernanceDataOnLoad();
+  }, [fetchGovernanceDataOnLoad]);
+};

--- a/src/dex-ui/layouts/TopMenuBar/TopMenuBar.tsx
+++ b/src/dex-ui/layouts/TopMenuBar/TopMenuBar.tsx
@@ -18,7 +18,6 @@ import {
   Skeleton,
   Circle,
   Flex,
-  Spacer,
   Tag,
 } from "@chakra-ui/react";
 import { ExternalLinkIcon } from "@chakra-ui/icons";

--- a/src/dex-ui/layouts/TopMenuBar/TopMenuBar.tsx
+++ b/src/dex-ui/layouts/TopMenuBar/TopMenuBar.tsx
@@ -18,6 +18,8 @@ import {
   Skeleton,
   Circle,
   Flex,
+  Spacer,
+  Tag,
 } from "@chakra-ui/react";
 import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { useDexContext } from "../../hooks";
@@ -50,17 +52,20 @@ const TopMenuBar = (props: TopMenuBarProps): JSX.Element => {
 
   return (
     <Menu>
-      <Flex padding="2rem 1rem" w="100%" alignItems="center">
+      <Flex padding="2rem 1rem" marginBottom="3rem" w="100%" alignItems="center">
         <Box flex="1.5">
-          <Text flex="1" textStyle="h5" padding="0.4rem 0">
-            Hedera Open DEX
-          </Text>
+          <HStack spacing="0.5rem">
+            <Text textStyle="h5">Hedera Open DEX</Text>
+            <Tag textStyle="b4" size="sm">
+              Pre-Alpha
+            </Tag>
+          </HStack>
         </Box>
         <Box flex="1">
           <Center>
-            {props.menuOptions.map((menuOption) => {
+            {props.menuOptions.map((menuOption, index) => {
               return (
-                <Box flex="1">
+                <Box flex="1" key={index}>
                   <RouterLink key={menuOption} to={`/${menuOption.toLowerCase()}`}>
                     <MenuItem justifyContent="center" _hover={{ bg: "gray.200" }}>
                       <Text textStyle="b2-bold">{menuOption}</Text>
@@ -72,20 +77,18 @@ const TopMenuBar = (props: TopMenuBarProps): JSX.Element => {
           </Center>
         </Box>
         <Box flex="1.5">
-          <Box
-            textAlign="right"
-            float="right"
-            borderRadius="8px"
-            backgroundColor="#F2F2F4"
-            minWidth="350px"
-            width="fit-content"
-          >
+          <Box textAlign="right" float="right" borderRadius="8px" backgroundColor="#F2F2F4" width="fit-content">
             <Grid templateColumns="repeat(2, 1fr)">
-              <Skeleton padding="0.5em 1em" speed={0.4} fadeDuration={0} isLoaded={!app.isFeatureLoading("walletData")}>
-                <Flex justifyContent="center" alignItems="center">
+              <Flex justifyContent="center" alignItems="center">
+                <Skeleton
+                  padding="0.5em 1em"
+                  speed={0.4}
+                  fadeDuration={0}
+                  isLoaded={!app.isFeatureLoading("walletData")}
+                >
                   <Text textStyle="b2-bold">{walletData?.pairedAccountBalance?.hbars ?? "- ℏ"}</Text>
-                </Flex>
-              </Skeleton>
+                </Skeleton>
+              </Flex>
               <Popover>
                 <PopoverTrigger>
                   <Button bg="black" color="white" padding="0.5em 1em">

--- a/src/dex-ui/pages/CreateProposal/AddNewToken.tsx
+++ b/src/dex-ui/pages/CreateProposal/AddNewToken.tsx
@@ -4,33 +4,33 @@ export function AddNewToken(props: any) {
   return (
     <VStack alignItems="left" gap="10px">
       <FormControl>
-        <Input placeholder="Proposal Title" />
+        <Input variant="form-input" placeholder="Proposal Title" />
       </FormControl>
       <FormControl>
-        <Input placeholder="Description" />
+        <Input variant="form-input" placeholder="Description" />
       </FormControl>
       <FormControl>
-        <Input placeholder="Link to Discussion (Optional)" />
+        <Input variant="form-input" placeholder="Link to Discussion (Optional)" />
       </FormControl>
       <HStack>
         <FormControl>
-          <Input placeholder="Token Name" />
+          <Input variant="form-input" placeholder="Token Name" />
         </FormControl>
         <FormControl>
-          <Input placeholder="Token Symbol" />
+          <Input variant="form-input" placeholder="Token Symbol" />
         </FormControl>
       </HStack>
       <FormControl>
-        <Input placeholder="Link to Token Icon" />
+        <Input variant="form-input" placeholder="Link to Token Icon" />
       </FormControl>
       <FormControl>
-        <Input placeholder="Token Backing Organization" />
+        <Input variant="form-input" placeholder="Token Backing Organization" />
       </FormControl>
       <FormControl>
-        <Input placeholder="Link to Audit Report" />
+        <Input variant="form-input" placeholder="Link to Audit Report" />
       </FormControl>
       <FormControl>
-        <Input placeholder="Lorem ipsum long form question field" />
+        <Input variant="form-input" placeholder="Lorem ipsum long form question field" />
       </FormControl>
     </VStack>
   );

--- a/src/dex-ui/pages/CreateProposal/AddNewToken.tsx
+++ b/src/dex-ui/pages/CreateProposal/AddNewToken.tsx
@@ -1,10 +1,17 @@
 import { FormControl, HStack, Input, VStack } from "@chakra-ui/react";
+import { ChangeEvent } from "react";
 
-export function AddNewToken(props: any) {
+interface NewTokenProps {
+  title: string;
+  handleTitleChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export function AddNewToken(props: NewTokenProps) {
+  const { title, handleTitleChange } = props;
   return (
     <VStack alignItems="left" gap="10px">
       <FormControl>
-        <Input variant="form-input" placeholder="Proposal Title" />
+        <Input value={title} onChange={handleTitleChange} variant="form-input" placeholder="Proposal Title" />
       </FormControl>
       <FormControl>
         <Input variant="form-input" placeholder="Description" />

--- a/src/dex-ui/pages/CreateProposal/CreateProposal.tsx
+++ b/src/dex-ui/pages/CreateProposal/CreateProposal.tsx
@@ -1,10 +1,12 @@
 import { Box, Breadcrumb, BreadcrumbItem, BreadcrumbLink, Button, Flex, Spacer, Text, VStack } from "@chakra-ui/react";
 import { Link as ReachLink } from "react-router-dom";
+import { useDexContext } from "../../hooks";
 import { AddNewToken } from "./AddNewToken";
 
 // interface CreateProposalProps {}
 
 export const CreateProposal = (props: any) => {
+  const { governance } = useDexContext(({ governance }) => ({ governance }));
   return (
     <VStack alignItems="left" width="100%">
       <Breadcrumb flex="1">
@@ -26,7 +28,13 @@ export const CreateProposal = (props: any) => {
           <Flex flexDirection="row" justifyContent="end" gap="10px">
             <Button variant="seconday">Cancel</Button>
             <Button>Preview</Button>
-            <Button>Publish</Button>
+            <Button
+              onClick={() => {
+                governance.sendCreateNewTokenProposalTransaction();
+              }}
+            >
+              Publish
+            </Button>
           </Flex>
         </Box>
       </Flex>

--- a/src/dex-ui/pages/CreateProposal/CreateProposal.tsx
+++ b/src/dex-ui/pages/CreateProposal/CreateProposal.tsx
@@ -1,47 +1,103 @@
+import { WarningIcon } from "@chakra-ui/icons";
 import { Box, Breadcrumb, BreadcrumbItem, BreadcrumbLink, Button, Flex, Spacer, Text, VStack } from "@chakra-ui/react";
-import { Link as ReachLink } from "react-router-dom";
+import { ChangeEvent, useEffect, useState } from "react";
+import { Link as ReachLink, useNavigate } from "react-router-dom";
+import { LoadingDialog } from "../../../dex-ui-components";
 import { useDexContext } from "../../hooks";
 import { AddNewToken } from "./AddNewToken";
 
-// interface CreateProposalProps {}
+export interface CreateProposalLocationProps {
+  proposalTitle: string | undefined;
+  proposalTransactionId: string | undefined;
+  isProposalCreationSuccessful: boolean;
+}
 
 export const CreateProposal = (props: any) => {
   const { governance } = useDexContext(({ governance }) => ({ governance }));
+  const navigate = useNavigate();
+
+  /**
+   * Temporarily managing form values with standard React state.
+   * This should be replaced with Formik.
+   * */
+  const [title, setTitle] = useState("");
+  const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setTitle(event.target.value);
+  };
+
+  /**
+   * Hook for listening to the state of new proposal transaction. When a transaction
+   * - is waiting to be signed, a loading dialog is displayed.
+   * - fails, a failure dialog is displayed.
+   * - succeeds, the user is routed the governance page with a success message.
+   */
+  useEffect(() => {
+    if (governance.proposalTransacationState.status === "success") {
+      const { successPayload } = governance.proposalTransacationState;
+      const createProposalLocationProps = {
+        state: {
+          proposalTitle: successPayload?.proposal.title,
+          proposalTransactionId: successPayload?.transactionResponse.transactionId.toString(),
+          isProposalCreationSuccessful: true,
+        } as CreateProposalLocationProps,
+      };
+      navigate("/governance", createProposalLocationProps);
+      governance.clearProposalTransactionState();
+    }
+  }, [governance.proposalTransacationState.status]);
+
   return (
-    <VStack alignItems="left" width="100%">
-      <Breadcrumb flex="1">
-        <BreadcrumbItem>
-          <BreadcrumbLink as={ReachLink} to="/governance/select-proposal-type">
-            <Text textStyle="link">{"< Select Proposal Type"}</Text>
-          </BreadcrumbLink>
-        </BreadcrumbItem>
-      </Breadcrumb>
-      <Text flex="1" textStyle="h2" paddingBottom="3rem">
-        Create New Proposal
-      </Text>
-      <Flex flexDirection="column" alignItems="center">
-        <Box width="600px">
-          <Text textStyle="h3">Add New Token</Text>
-          <Spacer padding="1rem" />
-          <AddNewToken />
-          <Spacer padding="1.5rem" />
-          <Flex flexDirection="row" justifyContent="end" gap="10px">
-            <Button variant="secondary" padding="10px 27px" height="40px">
-              Preview
-            </Button>
-            <Button
-              variant="primary"
-              padding="10px 27px"
-              height="40px"
-              onClick={() => {
-                governance.sendCreateNewTokenProposalTransaction();
-              }}
-            >
-              Publish
-            </Button>
-          </Flex>
-        </Box>
-      </Flex>
-    </VStack>
+    <>
+      <VStack alignItems="left" width="100%">
+        <Breadcrumb flex="1">
+          <BreadcrumbItem>
+            <BreadcrumbLink as={ReachLink} to="/governance/select-proposal-type">
+              <Text textStyle="link">{"< Select Proposal Type"}</Text>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </Breadcrumb>
+        <Text flex="1" textStyle="h2" paddingBottom="3rem">
+          Create New Proposal
+        </Text>
+        <Flex flexDirection="column" alignItems="center">
+          <Box width="600px">
+            <Text textStyle="h3">Add New Token</Text>
+            <Spacer padding="1rem" />
+            <AddNewToken title={title} handleTitleChange={handleTitleChange} />
+            <Spacer padding="1.5rem" />
+            <Flex flexDirection="row" justifyContent="end" gap="10px">
+              <Button variant="secondary" padding="10px 27px" height="40px">
+                Preview
+              </Button>
+              <Button
+                variant="primary"
+                padding="10px 27px"
+                height="40px"
+                onClick={() => {
+                  governance.sendCreateNewTokenProposalTransaction({ title });
+                }}
+              >
+                Publish
+              </Button>
+            </Flex>
+          </Box>
+        </Flex>
+      </VStack>
+      <LoadingDialog
+        isOpen={governance.proposalTransacationState.status === "in progress"}
+        message={"Please confirm the proposal creation transaction in your wallet to proceed."}
+      />
+      <LoadingDialog
+        isOpen={governance.proposalTransacationState.status === "error"}
+        message={governance.proposalTransacationState.errorMessage ?? ""}
+        icon={<WarningIcon color="#EF5C5C" h={10} w={10} />}
+        buttonConfig={{
+          text: "Dismiss",
+          onClick: () => {
+            governance.clearProposalTransactionState();
+          },
+        }}
+      />
+    </>
   );
 };

--- a/src/dex-ui/pages/CreateProposal/CreateProposal.tsx
+++ b/src/dex-ui/pages/CreateProposal/CreateProposal.tsx
@@ -22,13 +22,17 @@ export const CreateProposal = (props: any) => {
       <Flex flexDirection="column" alignItems="center">
         <Box width="600px">
           <Text textStyle="h3">Add New Token</Text>
-          <Spacer padding="0.5rem" />
+          <Spacer padding="1rem" />
           <AddNewToken />
-          <Spacer padding="0.5rem" />
+          <Spacer padding="1.5rem" />
           <Flex flexDirection="row" justifyContent="end" gap="10px">
-            <Button variant="seconday">Cancel</Button>
-            <Button>Preview</Button>
+            <Button variant="secondary" padding="10px 27px" height="40px">
+              Preview
+            </Button>
             <Button
+              variant="primary"
+              padding="10px 27px"
+              height="40px"
               onClick={() => {
                 governance.sendCreateNewTokenProposalTransaction();
               }}

--- a/src/dex-ui/pages/CreateProposal/CreateProposal.tsx
+++ b/src/dex-ui/pages/CreateProposal/CreateProposal.tsx
@@ -4,6 +4,7 @@ import { ChangeEvent, useEffect, useState } from "react";
 import { Link as ReachLink, useNavigate } from "react-router-dom";
 import { LoadingDialog } from "../../../dex-ui-components";
 import { useDexContext } from "../../hooks";
+import { TransactionStatus } from "../../store/appSlice";
 import { AddNewToken } from "./AddNewToken";
 
 export interface CreateProposalLocationProps {
@@ -18,7 +19,7 @@ export const CreateProposal = (props: any) => {
 
   /**
    * Temporarily managing form values with standard React state.
-   * This should be replaced with Formik.
+   * This should be replaced with Formik in the future.
    * */
   const [title, setTitle] = useState("");
   const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -26,13 +27,12 @@ export const CreateProposal = (props: any) => {
   };
 
   /**
-   * Hook for listening to the state of new proposal transaction. When a transaction
-   * - is waiting to be signed, a loading dialog is displayed.
-   * - fails, a failure dialog is displayed.
-   * - succeeds, the user is routed the governance page with a success message.
+   * When a new proposal transaction is successful, the user will be redirected to the governance
+   * page. Location props are passed to the governance page to populate the transaction
+   * success message.
    */
   useEffect(() => {
-    if (governance.proposalTransacationState.status === "success") {
+    if (governance.proposalTransacationState.status === TransactionStatus.SUCCESS) {
       const { successPayload } = governance.proposalTransacationState;
       const createProposalLocationProps = {
         state: {
@@ -44,6 +44,7 @@ export const CreateProposal = (props: any) => {
       navigate("/governance", createProposalLocationProps);
       governance.clearProposalTransactionState();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [governance.proposalTransacationState.status]);
 
   return (
@@ -84,11 +85,11 @@ export const CreateProposal = (props: any) => {
         </Flex>
       </VStack>
       <LoadingDialog
-        isOpen={governance.proposalTransacationState.status === "in progress"}
+        isOpen={governance.proposalTransacationState.status === TransactionStatus.IN_PROGRESS}
         message={"Please confirm the proposal creation transaction in your wallet to proceed."}
       />
       <LoadingDialog
-        isOpen={governance.proposalTransacationState.status === "error"}
+        isOpen={governance.proposalTransacationState.status === TransactionStatus.ERROR}
         message={governance.proposalTransacationState.errorMessage ?? ""}
         icon={<WarningIcon color="#EF5C5C" h={10} w={10} />}
         buttonConfig={{

--- a/src/dex-ui/pages/CreateProposal/SelectProposalType.tsx
+++ b/src/dex-ui/pages/CreateProposal/SelectProposalType.tsx
@@ -98,7 +98,7 @@ export const SelectProposalType = (props: any) => {
           Continue
         </Button>
         <Spacer padding="0.25rem" />
-        <Button variant="secondary" width="437px">
+        <Button variant="cancel" width="437px" onClick={() => navigate(`/governance`)}>
           Cancel
         </Button>
       </Center>

--- a/src/dex-ui/pages/Governance/Governance.tsx
+++ b/src/dex-ui/pages/Governance/Governance.tsx
@@ -1,79 +1,12 @@
-import { AccountId } from "@hashgraph/sdk";
 import { useNavigate } from "react-router-dom";
 import { Text, Button, Flex, Spacer, VStack } from "@chakra-ui/react";
 import { ProposalCard } from "./ProposalCard";
-import { Proposal } from "./types";
-
-/** TODO: Replace will real data */
-const mockProposalData: Proposal[] = [
-  {
-    title: "New Token Proposal 1",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: "Active",
-    timeRemaining: "12d 4 hrs",
-    voteCount: {
-      yes: 123,
-      no: 462,
-      abstain: 3000,
-    },
-  },
-  {
-    title: "New Token Proposal 2",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: "Active",
-    timeRemaining: "12d 4 hrs",
-    voteCount: {
-      yes: 123,
-      no: 462,
-      abstain: 3000,
-    },
-  },
-  {
-    title: "New Token Proposal 5",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: "Active",
-    timeRemaining: "12d 4 hrs",
-    voteCount: {
-      yes: 123,
-      no: 462,
-      abstain: 3000,
-    },
-  },
-  {
-    title: "New Token Proposal 3",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-    adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: "Passed",
-    timeRemaining: "12d 4 hrs",
-    voteCount: {
-      yes: 123,
-      no: 462,
-      abstain: 3000,
-    },
-  },
-  {
-    title: "New Token Proposal 4",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: "Failed",
-    timeRemaining: "6d 4 hrs",
-    voteCount: {
-      yes: 232,
-      no: 212,
-      abstain: 2203,
-    },
-  },
-];
+import { useDexContext } from "../../hooks";
+import { useGovernanceData } from "../../hooks/useGovernanceData";
 
 export const Governance = (): JSX.Element => {
+  const { governance } = useDexContext(({ governance }) => ({ governance }));
+  useGovernanceData();
   const navigate = useNavigate();
 
   return (
@@ -83,7 +16,7 @@ export const Governance = (): JSX.Element => {
       <Text textStyle="h3">Active Proposals</Text>
       <Spacer margin="0.5rem" />
       <VStack>
-        {mockProposalData
+        {governance.proposals
           .filter((proposal) => proposal.status === "Active")
           .map((proposal, index) => (
             <ProposalCard proposal={proposal} key={index} />
@@ -104,7 +37,7 @@ export const Governance = (): JSX.Element => {
       </Flex>
       <Spacer margin="0.5rem" />
       <VStack>
-        {mockProposalData.map((proposal, index) => (
+        {governance.proposals.map((proposal, index) => (
           <ProposalCard proposal={proposal} key={index} />
         ))}
       </VStack>

--- a/src/dex-ui/pages/Governance/Governance.tsx
+++ b/src/dex-ui/pages/Governance/Governance.tsx
@@ -1,16 +1,40 @@
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Text, Button, Flex, Spacer, VStack } from "@chakra-ui/react";
 import { ProposalCard } from "./ProposalCard";
 import { useDexContext } from "../../hooks";
 import { useGovernanceData } from "../../hooks/useGovernanceData";
+import { useState } from "react";
+import { Notification, NotficationTypes } from "../../../dex-ui-components";
+import { CreateProposalLocationProps } from "../CreateProposal";
+import { createHashScanLink } from "../../utils";
 
 export const Governance = (): JSX.Element => {
   const { governance } = useDexContext(({ governance }) => ({ governance }));
   useGovernanceData();
   const navigate = useNavigate();
+  const locationState = useLocation().state as CreateProposalLocationProps;
+  const [shouldShowNotification, setShouldShowNotification] = useState<boolean>(
+    locationState?.isProposalCreationSuccessful ?? false
+  );
 
   return (
     <Flex flexDirection="column" width="100%">
+      {shouldShowNotification ? (
+        <>
+          <Notification
+            type={NotficationTypes.SUCCESS}
+            message={`You have created ${locationState.proposalTitle}`}
+            isLinkShown={true}
+            linkText="View in HashScan"
+            linkRef={createHashScanLink(locationState.proposalTransactionId)}
+            isCloseButtonShown={true}
+            handleClickClose={() => setShouldShowNotification(false)}
+          />
+          <Spacer margin="0.25rem 0rem" />
+        </>
+      ) : (
+        <></>
+      )}
       <Text textStyle="h2">Governance</Text>
       <Spacer margin="1rem" />
       <Text textStyle="h3">Active Proposals</Text>

--- a/src/dex-ui/pages/Pools/Pools.tsx
+++ b/src/dex-ui/pages/Pools/Pools.tsx
@@ -9,18 +9,18 @@ import {
   Tabs,
   Link,
   Text,
-  Tag,
-  TagCloseButton,
   Skeleton,
+  Spacer,
 } from "@chakra-ui/react";
 import { Link as RouterLink, useLocation, useNavigate } from "react-router-dom";
 import { useCallback, useEffect, useState } from "react";
 import { DataTable, DataTableColumnConfig } from "../../../dex-ui-components/base/DataTable";
+import { NotficationTypes, Notification } from "../../../dex-ui-components";
 import { formatPoolMetrics, formatUserPoolMetrics } from "./formatters";
 import { isEmpty } from "ramda";
 import { useDexContext, usePoolsData } from "../../hooks";
-import { ExternalLinkIcon } from "@chakra-ui/icons";
 import { Pool, UserPool } from "../../store/poolsSlice";
+import { createHashScanLink } from "../../utils";
 
 export interface FormattedUserPoolDetails {
   name: string;
@@ -199,15 +199,6 @@ const Pools = (): JSX.Element => {
       : [];
   };
 
-  const getHashScanLink = useCallback(() => {
-    const transactionId = pools.withdrawState.successPayload?.transactionResponse.transactionId.toString();
-    const urlFormattedTimestamp = transactionId?.split("@")[1].replace(".", "-");
-    const formattedTransactionId = `${transactionId?.split("@")[0]}-${urlFormattedTimestamp}`;
-    // format: https://hashscan.io/#/testnet/transaction/0.0.34744739-1665448985-817445871
-    // TODO: set testnet/mainnet based on network
-    return `https://hashscan.io/#/testnet/transaction/${formattedTransactionId}`;
-  }, [pools.withdrawState.successPayload]);
-
   return (
     <>
       <Tabs
@@ -217,35 +208,26 @@ const Pools = (): JSX.Element => {
         onChange={(index) => setPoolsParamsState({ ...poolsParamsState, selectedTab: index })}
       >
         {pools.withdrawState.status === "success" && poolsParamsState.showSuccessfulWithdrawalMessage ? (
-          <Tag width={"calc(100%) - 32px"} padding={"8px"} margin={"16px"} backgroundColor={"#00e64d33"}>
-            <Flex width={"100%"} flexWrap={"wrap"}>
-              <Text color={"#000000"}>
-                {`Withdrew ${pools.withdrawState.successPayload?.lpTokenAmount} LP Tokens from 
-                ${pools.withdrawState.successPayload?.lpTokenSymbol} 
-                ${pools.withdrawState.successPayload?.fee} fee Pool.`}
-                &nbsp;
-              </Text>
-              {
-                // TODO: make link to HashScan its own component (also being used in Swap component)}
+          <>
+            <Notification
+              type={NotficationTypes.SUCCESS}
+              message={`Withdrew ${pools.withdrawState.successPayload?.lpTokenAmount} LP Tokens from 
+        ${pools.withdrawState.successPayload?.lpTokenSymbol} 
+        ${pools.withdrawState.successPayload?.fee} fee Pool.`}
+              isLinkShown={true}
+              linkText="View in HashScan"
+              linkRef={createHashScanLink(
+                pools.withdrawState.successPayload?.transactionResponse.transactionId.toString()
+              )}
+              isCloseButtonShown={true}
+              handleClickClose={() =>
+                setPoolsParamsState({ ...poolsParamsState, showSuccessfulWithdrawalMessage: false })
               }
-              <Link
-                width={"fit-content"}
-                display={"flex"}
-                alignItems={"center"}
-                color={"#0180FF"}
-                href={getHashScanLink()}
-                isExternal
-              >
-                <Text textDecoration={"underline"}>View in HashScan</Text> <ExternalLinkIcon />
-              </Link>
-            </Flex>
-            <TagCloseButton
-              color={"#000000"}
-              onClick={() => setPoolsParamsState({ ...poolsParamsState, showSuccessfulWithdrawalMessage: false })}
             />
-          </Tag>
+            <Spacer margin="0.25rem 0rem" />
+          </>
         ) : (
-          ""
+          <></>
         )}
         <TabList
           display={"flex"}

--- a/src/dex-ui/pages/Swap/Swap.tsx
+++ b/src/dex-ui/pages/Swap/Swap.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, HStack, Spacer } from "@chakra-ui/react";
+import { Box, Center, HStack } from "@chakra-ui/react";
 import { SwapTokens } from "../../../dex-ui-components";
 import { useDexContext } from "../../hooks";
 import { formatSwapPageData } from "./formatters";

--- a/src/dex-ui/pages/Swap/Swap.tsx
+++ b/src/dex-ui/pages/Swap/Swap.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, HStack } from "@chakra-ui/react";
+import { Box, Center, HStack, Spacer } from "@chakra-ui/react";
 import { SwapTokens } from "../../../dex-ui-components";
 import { useDexContext } from "../../hooks";
 import { formatSwapPageData } from "./formatters";

--- a/src/dex-ui/pages/Withdraw/Withdraw.tsx
+++ b/src/dex-ui/pages/Withdraw/Withdraw.tsx
@@ -64,7 +64,7 @@ const Withdraw = () => {
       }
     } else {
       // no pool indicated, so redirect to My Pools page
-      navigate("/pool", { state: { withdrawSuccessful: false, selectedTab: 1 } as PoolsLocationProps });
+      navigate("/pools", { state: { withdrawSuccessful: false, selectedTab: 1 } as PoolsLocationProps });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pools]);
@@ -82,7 +82,7 @@ const Withdraw = () => {
     }));
 
     if (pools.withdrawState.status === "success") {
-      navigate("/pool", { state: { withdrawSuccessful: true, selectedTab: 1 } as PoolsLocationProps });
+      navigate("/pools", { state: { withdrawSuccessful: true, selectedTab: 1 } as PoolsLocationProps });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pools.withdrawState]);

--- a/src/dex-ui/services/HederaService/types.ts
+++ b/src/dex-ui/services/HederaService/types.ts
@@ -2,7 +2,7 @@ import { BigNumber } from "bignumber.js";
 import { HashConnectSigner } from "hashconnect/dist/provider/signer";
 import { ContractId } from "@hashgraph/sdk";
 
-export interface AddLiquidityDetails {
+interface AddLiquidityDetails {
   firstTokenAddress: string;
   firstTokenQuantity: BigNumber;
   secondTokenAddress: string;
@@ -11,3 +11,12 @@ export interface AddLiquidityDetails {
   walletAddress: string;
   signer: HashConnectSigner;
 }
+
+interface CreateProposalParams {
+  targets: Array<string>;
+  fees: Array<number>;
+  calls: Array<Uint8Array>;
+  description: string;
+}
+
+export type { AddLiquidityDetails, CreateProposalParams };

--- a/src/dex-ui/services/HederaService/types.ts
+++ b/src/dex-ui/services/HederaService/types.ts
@@ -17,6 +17,7 @@ interface CreateProposalParams {
   fees: Array<number>;
   calls: Array<Uint8Array>;
   description: string;
+  signer: HashConnectSigner;
 }
 
 export type { AddLiquidityDetails, CreateProposalParams };

--- a/src/dex-ui/services/constants.ts
+++ b/src/dex-ui/services/constants.ts
@@ -34,6 +34,8 @@ export const A_B_PAIR_TOKEN_ID = "0.0.48769790";
 
 export const USDC_TOKEN_ID = "0.0.2276691";
 
+export const GOVERNANCE_PROXY_ID = "0.0.48634267";
+
 export const TOKEN_SYMBOL_TO_ACCOUNT_ID = new Map<string, string>([
   [TOKEN_A_SYMBOL, TOKEN_A_ID],
   [TOKEN_B_SYMBOL, TOKEN_B_ID],

--- a/src/dex-ui/store/appSlice/types.ts
+++ b/src/dex-ui/store/appSlice/types.ts
@@ -1,5 +1,6 @@
 import { StateCreator } from "zustand";
 import { DEXState } from "..";
+import { GovernanceState } from "../governanceSlice";
 import { PoolsState } from "../poolsSlice";
 import { SwapState } from "../swapSlice";
 import { WalletState } from "../walletSlice";
@@ -9,7 +10,7 @@ enum AppActionType {
   SET_FEATURES_AS_LOADED = "app/SET_FEATURES_AS_LOADED",
 }
 
-type AppFeatures = keyof WalletState | keyof SwapState | keyof PoolsState;
+type AppFeatures = keyof WalletState | keyof SwapState | keyof PoolsState | keyof GovernanceState;
 
 interface AppState {
   featuresLoading: Set<AppFeatures>;

--- a/src/dex-ui/store/appSlice/types.ts
+++ b/src/dex-ui/store/appSlice/types.ts
@@ -5,6 +5,13 @@ import { PoolsState } from "../poolsSlice";
 import { SwapState } from "../swapSlice";
 import { WalletState } from "../walletSlice";
 
+enum TransactionStatus {
+  INIT = "init",
+  IN_PROGRESS = "in progress",
+  SUCCESS = "success",
+  ERROR = "error",
+}
+
 enum AppActionType {
   SET_FEATURES_AS_LOADING = "app/SET_FEATURES_AS_LOADING",
   SET_FEATURES_AS_LOADED = "app/SET_FEATURES_AS_LOADED",
@@ -26,5 +33,5 @@ type AppStore = AppState & AppActions;
 
 type AppSlice = StateCreator<DEXState, [["zustand/devtools", never], ["zustand/immer", never]], [], AppStore>;
 
-export { AppActionType };
+export { AppActionType, TransactionStatus };
 export type { AppSlice, AppStore, AppState, AppActions, AppFeatures };

--- a/src/dex-ui/store/createDEXStore.ts
+++ b/src/dex-ui/store/createDEXStore.ts
@@ -7,6 +7,7 @@ import { createSwapSlice, SwapStore } from "./swapSlice";
 import { createPoolsSlice, PoolsStore } from "./poolsSlice";
 import { DEXProviderProps } from "../context";
 import { DEFAULT_APP_METADATA } from "../context/constants";
+import { createGovernanceSlice, GovernanceStore } from "./governanceSlice";
 
 interface DEXState {
   context: DEXProviderProps;
@@ -14,6 +15,7 @@ interface DEXState {
   wallet: WalletStore;
   swap: SwapStore;
   pools: PoolsStore;
+  governance: GovernanceStore;
 }
 
 type DEXStore = ReturnType<typeof createDEXStore>;
@@ -33,6 +35,7 @@ const createDEXStore = (intialContext: DEXProviderProps) => {
         wallet: { ...createWalletSlice(...params) },
         swap: { ...createSwapSlice(...params) },
         pools: { ...createPoolsSlice(...params) },
+        governance: { ...createGovernanceSlice(...params) },
       }))
     )
   );

--- a/src/dex-ui/store/governanceSlice/governanceSlice.ts
+++ b/src/dex-ui/store/governanceSlice/governanceSlice.ts
@@ -1,7 +1,15 @@
 import { AccountId, ContractId } from "@hashgraph/sdk";
 import { HederaService, WalletService } from "../../services";
 import { getErrorMessage } from "../../utils";
-import { GovernanceActionType, GovernanceSlice, GovernanceState, GovernanceStore, Proposal } from "./type";
+import { TransactionStatus } from "../appSlice";
+import {
+  GovernanceActionType,
+  GovernanceSlice,
+  GovernanceState,
+  GovernanceStore,
+  Proposal,
+  ProposalStatus,
+} from "./type";
 
 /** TODO: Replace will real data */
 const mockProposalData: Proposal[] = [
@@ -10,7 +18,7 @@ const mockProposalData: Proposal[] = [
     description: `Preview of the description lorem ipsum dolor sit amit consectetur 
       adipiscing elit Phasellus congue, sapien eu...`,
     author: AccountId.fromString("0.0.34728121"),
-    status: "Active",
+    status: ProposalStatus.ACTIVE,
     timeRemaining: "12d 4 hrs",
     voteCount: {
       yes: 123,
@@ -23,7 +31,7 @@ const mockProposalData: Proposal[] = [
     description: `Preview of the description lorem ipsum dolor sit amit consectetur 
       adipiscing elit Phasellus congue, sapien eu...`,
     author: AccountId.fromString("0.0.34728121"),
-    status: "Active",
+    status: ProposalStatus.ACTIVE,
     timeRemaining: "12d 4 hrs",
     voteCount: {
       yes: 123,
@@ -36,7 +44,7 @@ const mockProposalData: Proposal[] = [
     description: `Preview of the description lorem ipsum dolor sit amit consectetur 
       adipiscing elit Phasellus congue, sapien eu...`,
     author: AccountId.fromString("0.0.34728121"),
-    status: "Active",
+    status: ProposalStatus.ACTIVE,
     timeRemaining: "12d 4 hrs",
     voteCount: {
       yes: 123,
@@ -49,7 +57,7 @@ const mockProposalData: Proposal[] = [
     description: `Preview of the description lorem ipsum dolor sit amit consectetur 
     adipiscing elit Phasellus congue, sapien eu...`,
     author: AccountId.fromString("0.0.34728121"),
-    status: "Passed",
+    status: ProposalStatus.PASSED,
     timeRemaining: "12d 4 hrs",
     voteCount: {
       yes: 123,
@@ -62,7 +70,7 @@ const mockProposalData: Proposal[] = [
     description: `Preview of the description lorem ipsum dolor sit amit consectetur 
       adipiscing elit Phasellus congue, sapien eu...`,
     author: AccountId.fromString("0.0.34728121"),
-    status: "Failed",
+    status: ProposalStatus.FAILED,
     timeRemaining: "6d 4 hrs",
     voteCount: {
       yes: 232,
@@ -76,7 +84,7 @@ const initialGovernanceStore: GovernanceState = {
   proposals: [],
   errorMessage: null,
   proposalTransacationState: {
-    status: "init",
+    status: TransactionStatus.INIT,
     successPayload: null,
     errorMessage: "",
   },
@@ -121,7 +129,7 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
         ({ governance }) => {
           governance.proposalTransacationState = {
             ...initialGovernanceStore.proposalTransacationState,
-            status: "in progress",
+            status: TransactionStatus.IN_PROGRESS,
           };
           governance.errorMessage = initialGovernanceStore.errorMessage;
         },
@@ -151,7 +159,7 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
           set(
             ({ governance }) => {
               governance.proposalTransacationState = {
-                status: "success",
+                status: TransactionStatus.SUCCESS,
                 successPayload: {
                   proposal: { title },
                   transactionResponse: result,
@@ -172,7 +180,7 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
         set(
           ({ governance }) => {
             governance.proposalTransacationState = {
-              status: "error",
+              status: TransactionStatus.ERROR,
               successPayload: null,
               errorMessage: errorMessage,
             };

--- a/src/dex-ui/store/governanceSlice/governanceSlice.ts
+++ b/src/dex-ui/store/governanceSlice/governanceSlice.ts
@@ -1,0 +1,150 @@
+import { AccountId, TokenId, ContractId } from "@hashgraph/sdk";
+import { HederaService } from "../../services";
+import { getErrorMessage } from "../../utils";
+import { GovernanceActionType, GovernanceSlice, GovernanceState, GovernanceStore, Proposal } from "./type";
+
+/** TODO: Replace will real data */
+const mockProposalData: Proposal[] = [
+  {
+    title: "New Token Proposal 1",
+    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
+      adipiscing elit Phasellus congue, sapien eu...`,
+    author: AccountId.fromString("0.0.34728121"),
+    status: "Active",
+    timeRemaining: "12d 4 hrs",
+    voteCount: {
+      yes: 123,
+      no: 462,
+      abstain: 3000,
+    },
+  },
+  {
+    title: "New Token Proposal 2",
+    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
+      adipiscing elit Phasellus congue, sapien eu...`,
+    author: AccountId.fromString("0.0.34728121"),
+    status: "Active",
+    timeRemaining: "12d 4 hrs",
+    voteCount: {
+      yes: 123,
+      no: 462,
+      abstain: 3000,
+    },
+  },
+  {
+    title: "New Token Proposal 5",
+    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
+      adipiscing elit Phasellus congue, sapien eu...`,
+    author: AccountId.fromString("0.0.34728121"),
+    status: "Active",
+    timeRemaining: "12d 4 hrs",
+    voteCount: {
+      yes: 123,
+      no: 462,
+      abstain: 3000,
+    },
+  },
+  {
+    title: "New Token Proposal 3",
+    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
+    adipiscing elit Phasellus congue, sapien eu...`,
+    author: AccountId.fromString("0.0.34728121"),
+    status: "Passed",
+    timeRemaining: "12d 4 hrs",
+    voteCount: {
+      yes: 123,
+      no: 462,
+      abstain: 3000,
+    },
+  },
+  {
+    title: "New Token Proposal 4",
+    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
+      adipiscing elit Phasellus congue, sapien eu...`,
+    author: AccountId.fromString("0.0.34728121"),
+    status: "Failed",
+    timeRemaining: "6d 4 hrs",
+    voteCount: {
+      yes: 232,
+      no: 212,
+      abstain: 2203,
+    },
+  },
+];
+
+const initialGovernanceStore: GovernanceState = {
+  proposals: [],
+  errorMessage: null,
+  proposalTransacationState: {
+    status: "init",
+    successPayload: null,
+    errorMessage: "",
+  },
+};
+
+/**
+ *
+ * @returns
+ */
+const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
+  return {
+    ...initialGovernanceStore,
+    fetchProposals: async () => {
+      const { app } = get();
+      app.setFeaturesAsLoading(["proposals"]);
+      set({}, false, GovernanceActionType.FETCH_PROPOSALS_STARTED);
+      try {
+        set(
+          ({ governance }) => {
+            governance.proposals = mockProposalData;
+          },
+          false,
+          GovernanceActionType.FETCH_PROPOSALS_SUCCEEDED
+        );
+      } catch (error) {
+        const errorMessage = getErrorMessage(error);
+        set(
+          ({ governance }) => {
+            governance.errorMessage = errorMessage;
+          },
+          false,
+          GovernanceActionType.FETCH_PROPOSALS_FAILED
+        );
+      }
+      app.setFeaturesAsLoaded(["proposals"]);
+    },
+    sendCreateNewTokenProposalTransaction: async () => {
+      const { context, wallet, app } = get();
+      set({}, false, GovernanceActionType.SEND_CREATE_NEW_TOKEN_PROPOSAL_STARTED);
+      try {
+        const tokenId = TokenId.fromString("0.0.48602743");
+
+        const BASE_CONTRACT_ADDRESS = ContractId.fromString("0.0.48585457").toSolidityAddress();
+        const targets = [BASE_CONTRACT_ADDRESS];
+        const fees = [0];
+        const associateToken = new Uint8Array([255]); //await associateTokenPublicCallData(tokenId);
+        const calls = [associateToken];
+        const description = "Create token proposal 3";
+        HederaService.createProposal({ targets, fees, calls, description });
+        set(
+          ({ governance }) => {
+            governance.proposals = mockProposalData;
+          },
+          false,
+          GovernanceActionType.SEND_CREATE_NEW_TOKEN_PROPOSAL_SUCCEEDED
+        );
+      } catch (error) {
+        const errorMessage = getErrorMessage(error);
+        set(
+          ({ governance }) => {
+            governance.errorMessage = errorMessage;
+          },
+          false,
+          GovernanceActionType.SEND_CREATE_NEW_TOKEN_PROPOSAL_FAILED
+        );
+      }
+    },
+  };
+};
+
+export { createGovernanceSlice };

--- a/src/dex-ui/store/governanceSlice/governanceSlice.ts
+++ b/src/dex-ui/store/governanceSlice/governanceSlice.ts
@@ -124,7 +124,7 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
         const fees = [0];
         const associateToken = new Uint8Array([255]); //await associateTokenPublicCallData(tokenId);
         const calls = [associateToken];
-        const description = "Create token proposal 3";
+        const description = "Create token proposal 5";
         HederaService.createProposal({ targets, fees, calls, description });
         set(
           ({ governance }) => {

--- a/src/dex-ui/store/governanceSlice/index.ts
+++ b/src/dex-ui/store/governanceSlice/index.ts
@@ -1,0 +1,2 @@
+export * from "./governanceSlice";
+export * from "./type";

--- a/src/dex-ui/store/governanceSlice/type.ts
+++ b/src/dex-ui/store/governanceSlice/type.ts
@@ -25,11 +25,15 @@ enum GovernanceActionType {
   SEND_CREATE_NEW_TOKEN_PROPOSAL_STARTED = "governance/SEND_CREATE_NEW_TOKEN_PROPOSAL_STARTED",
   SEND_CREATE_NEW_TOKEN_PROPOSAL_SUCCEEDED = "governance/SEND_CREATE_NEW_TOKEN_PROPOSAL_SUCCEEDED",
   SEND_CREATE_NEW_TOKEN_PROPOSAL_FAILED = "governance/SEND_CREATE_NEW_TOKEN_PROPOSAL_FAILED",
+  CLEAR_PROPOSAL_TRANSACTION_STATE = "governance/CLEAR_PROPOSAL_TRANSACTION_STATE",
 }
 
 interface ProposalTransacationState {
   status: "init" | "in progress" | "success" | "error";
   successPayload: {
+    proposal: {
+      title: string;
+    };
     transactionResponse: TransactionResponse;
   } | null;
   errorMessage: string;
@@ -41,9 +45,13 @@ interface GovernanceState {
   proposalTransacationState: ProposalTransacationState;
 }
 
+interface sendCreateNewTokenProposalParams {
+  title: string;
+}
 interface GovernanceActions {
   fetchProposals: () => Promise<void>;
-  sendCreateNewTokenProposalTransaction: () => Promise<void>;
+  sendCreateNewTokenProposalTransaction: ({ title }: sendCreateNewTokenProposalParams) => Promise<void>;
+  clearProposalTransactionState: () => void;
 }
 
 type GovernanceStore = GovernanceState & GovernanceActions;

--- a/src/dex-ui/store/governanceSlice/type.ts
+++ b/src/dex-ui/store/governanceSlice/type.ts
@@ -1,9 +1,20 @@
 import { TransactionResponse, AccountId } from "@hashgraph/sdk";
 import { StateCreator } from "zustand";
 import { DEXState } from "..";
+import { TransactionStatus } from "../appSlice";
 
-type VotingStatus = "Review" | "Active" | "Queued to Execute" | "Executed";
-type ProposalStatus = "Active" | "Passed" | "Failed";
+enum VotingStatus {
+  REVIEW = "Review",
+  ACTIVE = "Active",
+  QUEUED = "Queued to Execute",
+  EXECUTED = "Executed",
+}
+
+enum ProposalStatus {
+  ACTIVE = "Active",
+  PASSED = "Passed",
+  FAILED = "Failed",
+}
 
 interface Proposal {
   title: string;
@@ -29,7 +40,7 @@ enum GovernanceActionType {
 }
 
 interface ProposalTransacationState {
-  status: "init" | "in progress" | "success" | "error";
+  status: TransactionStatus;
   successPayload: {
     proposal: {
       title: string;
@@ -63,13 +74,5 @@ type GovernanceSlice = StateCreator<
   GovernanceStore
 >;
 
-export { GovernanceActionType };
-export type {
-  GovernanceSlice,
-  GovernanceStore,
-  GovernanceState,
-  GovernanceActions,
-  Proposal,
-  VotingStatus,
-  ProposalStatus,
-};
+export { GovernanceActionType, VotingStatus, ProposalStatus };
+export type { GovernanceSlice, GovernanceStore, GovernanceState, GovernanceActions, Proposal };

--- a/src/dex-ui/store/governanceSlice/type.ts
+++ b/src/dex-ui/store/governanceSlice/type.ts
@@ -1,0 +1,67 @@
+import { TransactionResponse, AccountId } from "@hashgraph/sdk";
+import { StateCreator } from "zustand";
+import { DEXState } from "..";
+
+type VotingStatus = "Review" | "Active" | "Queued to Execute" | "Executed";
+type ProposalStatus = "Active" | "Passed" | "Failed";
+
+interface Proposal {
+  title: string;
+  author: AccountId;
+  description: string;
+  status: ProposalStatus;
+  timeRemaining: string;
+  voteCount: {
+    yes: number;
+    no: number;
+    abstain: number;
+  };
+}
+
+enum GovernanceActionType {
+  FETCH_PROPOSALS_STARTED = "governance/FETCH_PROPOSALS_STARTED",
+  FETCH_PROPOSALS_SUCCEEDED = "governance/FETCH_PROPOSALS_SUCCEEDED",
+  FETCH_PROPOSALS_FAILED = "governance/FETCH_PROPOSALS_FAILED",
+  SEND_CREATE_NEW_TOKEN_PROPOSAL_STARTED = "governance/SEND_CREATE_NEW_TOKEN_PROPOSAL_STARTED",
+  SEND_CREATE_NEW_TOKEN_PROPOSAL_SUCCEEDED = "governance/SEND_CREATE_NEW_TOKEN_PROPOSAL_SUCCEEDED",
+  SEND_CREATE_NEW_TOKEN_PROPOSAL_FAILED = "governance/SEND_CREATE_NEW_TOKEN_PROPOSAL_FAILED",
+}
+
+interface ProposalTransacationState {
+  status: "init" | "in progress" | "success" | "error";
+  successPayload: {
+    transactionResponse: TransactionResponse;
+  } | null;
+  errorMessage: string;
+}
+
+interface GovernanceState {
+  proposals: Array<Proposal>;
+  errorMessage: string | null;
+  proposalTransacationState: ProposalTransacationState;
+}
+
+interface GovernanceActions {
+  fetchProposals: () => Promise<void>;
+  sendCreateNewTokenProposalTransaction: () => Promise<void>;
+}
+
+type GovernanceStore = GovernanceState & GovernanceActions;
+
+type GovernanceSlice = StateCreator<
+  DEXState,
+  [["zustand/devtools", never], ["zustand/immer", never]],
+  [],
+  GovernanceStore
+>;
+
+export { GovernanceActionType };
+export type {
+  GovernanceSlice,
+  GovernanceStore,
+  GovernanceState,
+  GovernanceActions,
+  Proposal,
+  VotingStatus,
+  ProposalStatus,
+};

--- a/src/dex-ui/store/poolsSlice/poolsSlice.ts
+++ b/src/dex-ui/store/poolsSlice/poolsSlice.ts
@@ -28,10 +28,7 @@ const initialPoolsStore: PoolsState = {
 };
 
 /**
- * A hook that provides access to functions that fetch transaction and account
- * information from a Hedera managed mirror node.
- * @returns - The state of the mirror node data as well as functions that can be used to fetch
- * the latest mirror node network data.
+ * @returns
  */
 const createPoolsSlice: PoolsSlice = (set, get): PoolsStore => {
   return {

--- a/src/dex-ui/styles/theme.ts
+++ b/src/dex-ui/styles/theme.ts
@@ -1,11 +1,12 @@
 import { extendTheme } from "@chakra-ui/react";
-import { TextStyles, ButtonStyles, NumberInputStyles, CardStyles } from "../../dex-ui-components/base";
+import { TextStyles, ButtonStyles, NumberInputStyles, InputStyles, CardStyles } from "../../dex-ui-components/base";
 
 export const DEXTheme = extendTheme({
   textStyles: TextStyles,
   components: {
     Button: ButtonStyles,
     NumberInput: NumberInputStyles,
+    Input: InputStyles,
     Card: CardStyles,
   },
 });

--- a/src/dex-ui/utils/ScrollToTop.tsx
+++ b/src/dex-ui/utils/ScrollToTop.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+export const ScrollToTop = (props: any) => {
+  const location = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location]);
+
+  return <>{props.children}</>;
+};

--- a/src/dex-ui/utils/formatters.ts
+++ b/src/dex-ui/utils/formatters.ts
@@ -1,0 +1,7 @@
+export const createHashScanLink = (transactionId: string | undefined) => {
+  const urlFormattedTimestamp = transactionId?.split("@")[1].replace(".", "-");
+  const formattedTransactionId = `${transactionId?.split("@")[0]}-${urlFormattedTimestamp}`;
+  // format: https://hashscan.io/#/testnet/transaction/0.0.34744739-1665448985-817445871
+  // TODO: set testnet/mainnet based on network
+  return `https://hashscan.io/testnet/transaction/${formattedTransactionId}`;
+};

--- a/src/dex-ui/utils/index.ts
+++ b/src/dex-ui/utils/index.ts
@@ -2,3 +2,5 @@ export * from "./numberFormatters";
 export * from "./poolMetrics";
 export * from "./time";
 export * from "./errorHandling";
+export * from "./formatters";
+export * from "./ScrollToTop";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import { enableMapSet } from "immer";
 import { createRoot } from "react-dom/client";
-import { DEX } from "./dex-ui";
+import { DEX } from "./dex-ui/DEX";
 import { DEXStoreProvider } from "./dex-ui/context";
 import { initializeServices } from "./dex-ui/services";
 import { DEFAULT_DEX_PROVIDER_PROPS } from "./dex-ui/store";


### PR DESCRIPTION
**Description**

Primary Changes:
- A user can now enter a new proposal title in the Add New Token proposal page and publish a proposal. The proposal transaction will be signed using the user's wallet.
- Failed transactions will result in a failure modal appearing in the application.
- The governance slice store was created to manage governance state and actions.

Other Improvements:
- All page routings now direct the user to the top of the destination page.
- Cancel button on the Proposal selection button now redirects the user to the governance page.
- Created a standalone Notification UI component to can be shared across the application.
- Minor UI updates to the text, page spacing, input styling, loading modal, and failure modal.
- Updated Storybook with basic Notification UI stories.

Screenshots:
![Screen Shot 2022-11-11 at 12 44 34 AM](https://user-images.githubusercontent.com/54907098/201271946-f64463cd-5d6a-471a-a083-405fd9e9a8c2.png)
![Screen Shot 2022-11-11 at 12 44 48 AM](https://user-images.githubusercontent.com/54907098/201271971-fa83dfc3-654b-46ac-9fc4-62f92272dee9.png)
![Screen Shot 2022-11-11 at 12 45 10 AM](https://user-images.githubusercontent.com/54907098/201271989-65310ab1-321e-448f-9ea9-9bea473172bc.png)
