### PR TITLE
feat: Added execute button, text proposal form, and logic to manage proposal types

### DIFF
--- a/src/dex-ui/pages/CreateProposal/ProposalForms/TextProposalForm.tsx
+++ b/src/dex-ui/pages/CreateProposal/ProposalForms/TextProposalForm.tsx
@@ -1,16 +1,59 @@
-import { FormControl, Input } from "@chakra-ui/react";
+import { Button, Flex, FormControl, FormErrorMessage, Input, Spacer } from "@chakra-ui/react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import { TextEditor } from "../../../../dex-ui-components";
+import { useDexContext } from "../../../hooks";
+import { ProposalType } from "../../../store/governanceSlice";
 
-/**
- * TODO: Update input fields to match full proposal creation feature set.
- * Use the TokenTransferProposalForm component as a reference for how to use Chakra
- * components and react-form-hooks to create a form.
- */
+type TextProposalFormData = {
+  title: string;
+  description: string;
+};
+
 function TextProposalForm() {
+  const { governance } = useDexContext(({ governance }) => ({ governance }));
+  const navigate = useNavigate();
+  const {
+    handleSubmit,
+    register,
+    formState: { errors, isSubmitting },
+  } = useForm<TextProposalFormData>();
+
+  const handleCancelClick = () => navigate("/governance");
+
+  async function onSubmit(data: TextProposalFormData) {
+    // TODO: Proposal Contract functions do not handle both title and description yet.
+    // description: data.description,
+    await governance.createProposal(ProposalType.Text, { title: data.title });
+  }
+
   return (
-    <form>
-      <FormControl>
-        <Input variant="form-input" id="title" placeholder="Proposal Title" />
-      </FormControl>
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Flex direction="column" gap="0.5rem">
+        <FormControl isInvalid={Boolean(errors.title)}>
+          <Input
+            variant="form-input"
+            id="title"
+            placeholder="Proposal Title"
+            {...register("title", {
+              required: { value: true, message: "A title is required." },
+            })}
+          />
+          <FormErrorMessage>{errors.title && errors.title.message}</FormErrorMessage>
+        </FormControl>
+        <FormControl>
+          <TextEditor id="description" placeholder="Description" />
+        </FormControl>
+        <Spacer padding="0.5rem" />
+        <Flex direction="row" justifyContent="right" gap="0.5rem">
+          <Button variant="secondary" padding="10px 27px" height="40px" onClick={handleCancelClick}>
+            Cancel
+          </Button>
+          <Button type="submit" variant="primary" padding="10px 27px" height="40px" isLoading={isSubmitting}>
+            Publish
+          </Button>
+        </Flex>
+      </Flex>
     </form>
   );
 }

--- a/src/dex-ui/pages/CreateProposal/ProposalForms/TokenTransferProposalForm.tsx
+++ b/src/dex-ui/pages/CreateProposal/ProposalForms/TokenTransferProposalForm.tsx
@@ -1,8 +1,10 @@
 import { Button, Flex, FormControl, FormErrorMessage, Input, Spacer } from "@chakra-ui/react";
 import { ReactElement } from "react";
 import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
 import { TextEditor } from "../../../../dex-ui-components";
 import { useDexContext } from "../../../hooks";
+import { ProposalType } from "../../../store/governanceSlice";
 
 type TokenTransferProposalFormData = {
   title: string;
@@ -14,14 +16,17 @@ type TokenTransferProposalFormData = {
 
 export function TokenTransferProposalForm(): ReactElement {
   const { governance } = useDexContext(({ governance }) => ({ governance }));
+  const navigate = useNavigate();
   const {
     handleSubmit,
     register,
     formState: { errors, isSubmitting },
   } = useForm<TokenTransferProposalFormData>();
 
+  const handleCancelClick = () => navigate("/governance");
+
   async function onSubmit(data: TokenTransferProposalFormData) {
-    await governance.createTransferTokenProposal({
+    await governance.createProposal(ProposalType.TokenTransfer, {
       title: data.title,
       // TODO: Proposal Contract functions do not handle both title and description yet.
       // description: data.description,
@@ -90,16 +95,21 @@ export function TokenTransferProposalForm(): ReactElement {
           </FormControl>
         </Flex>
         <Spacer padding="0.5rem" />
-        <Button
-          type="submit"
-          variant="primary"
-          padding="10px 27px"
-          height="40px"
-          isLoading={isSubmitting}
-          alignSelf="end"
-        >
-          Publish
-        </Button>
+        <Flex direction="row" justifyContent="right" gap="0.5rem">
+          <Button variant="secondary" padding="10px 27px" height="40px" onClick={handleCancelClick}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            padding="10px 27px"
+            height="40px"
+            isLoading={isSubmitting}
+            alignSelf="end"
+          >
+            Publish
+          </Button>
+        </Flex>
       </Flex>
     </form>
   );

--- a/src/dex-ui/pages/Governance/ProposalCard.tsx
+++ b/src/dex-ui/pages/Governance/ProposalCard.tsx
@@ -1,4 +1,4 @@
-import { Text, Box, Flex, Spacer, VStack } from "@chakra-ui/react";
+import { Text, Box, Flex, Spacer, VStack, Tag } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
 import { Card, HorizontalStackBarChart } from "../../../dex-ui-components";
 import { Color } from "../../../dex-ui-components/themes";
@@ -57,9 +57,14 @@ export const ProposalCard = (props: ProposalCardProps) => {
         <Box flex="12" padding="0.5rem 0">
           <VStack alignItems="start">
             <Flex width="100%" flexDirection="row">
-              <Text flex="4" textStyle="h3" textAlign="left">
-                {proposal.title}
-              </Text>
+              <Flex flex="8" textAlign="left">
+                <Text textStyle="h3" paddingRight="0.5rem">
+                  {proposal.title}
+                </Text>
+                <Tag textStyle="b3" size="sm">
+                  {proposal.type}
+                </Tag>
+              </Flex>
               <Spacer flex="1" />
               <Text flex="4" textAlign="right" textStyle="b2">{`Author ${proposal.author.toString()}`}</Text>
             </Flex>

--- a/src/dex-ui/pages/Governance/formatter.ts
+++ b/src/dex-ui/pages/Governance/formatter.ts
@@ -8,7 +8,7 @@ import { FormattedProposal } from "./types";
  * @returns A formatted version of the proposal data.
  */
 export const formatProposal = (proposal: Proposal): FormattedProposal => {
-  const { contractId, id, title, author, description, status, timeRemaining, state, votes } = proposal;
+  const { id, contractId, type, title, author, description, status, timeRemaining, state, votes } = proposal;
   const [yes, no, abstain, quorum, max] = [
     votes.yes?.toNumber(),
     votes.no?.toNumber(),
@@ -17,8 +17,9 @@ export const formatProposal = (proposal: Proposal): FormattedProposal => {
     votes.max?.toNumber(),
   ];
   return {
-    contractId,
     id: id.toString(),
+    contractId,
+    type,
     title,
     author: author.toString(),
     description,

--- a/src/dex-ui/pages/Governance/types.ts
+++ b/src/dex-ui/pages/Governance/types.ts
@@ -1,8 +1,9 @@
-import { ProposalStatus, ProposalState } from "../../store/governanceSlice";
+import { ProposalStatus, ProposalState, ProposalType } from "../../store/governanceSlice";
 
 interface FormattedProposal {
-  contractId: string;
   id: string;
+  contractId: string;
+  type: ProposalType | undefined;
   title: string | undefined;
   author: string;
   description: string;

--- a/src/dex-ui/services/HederaService/GovernorService.ts
+++ b/src/dex-ui/services/HederaService/GovernorService.ts
@@ -4,23 +4,90 @@ import { ContractId } from "@hashgraph/sdk";
 import { GovernorProxyContracts, TREASURY_ID } from "../constants";
 import { GovernorContractFunctions } from "./types";
 import { HashConnectSigner } from "hashconnect/dist/esm/provider/signer";
+import { queryContract } from "./utils";
 
+/**
+ * General format of service calls:
+ * 1 - Convert data types.
+ * 2 - Create contract parameters.
+ * 3 - Create and sign transaction.
+ * 4 - Send transaction to wallet and execute transaction.
+ * 5 - Extract and return resulting data.
+ */
+
+/**
+ * Fetches the current state of a governor proposal.
+ * @param contractId - The account id of the governor contract.
+ * @param proposalId - The id of the governor proposal.
+ * @returns The state of the proposal
+ */
+const fetchProposalState = async (contractId: string, proposalId: string): Promise<BigNumber | undefined> => {
+  const governorContractId = ContractId.fromString(contractId);
+  const preciseProposalId = BigNumber(proposalId);
+  const queryParams = new ContractFunctionParameters().addUint256(preciseProposalId);
+  const result = await queryContract(governorContractId, GovernorContractFunctions.GetState, queryParams);
+  const proposalState = result?.getUint256(0);
+  return proposalState;
+};
+
+/**
+ * TODO
+ * @param contractId -
+ * @param blockNumber -
+ * @returns
+ */
+const fetchQuorum = async (contractId: string, blockNumber: string): Promise<BigNumber | undefined> => {
+  const governorContractId = ContractId.fromString(contractId);
+  const preciseBlockNumber = BigNumber(blockNumber);
+  const queryParams = new ContractFunctionParameters().addUint256(preciseBlockNumber);
+  const result = await queryContract(governorContractId, GovernorContractFunctions.GetQuorum, queryParams);
+  const quorum = result?.getInt256(0);
+  return quorum;
+};
+interface ProposalVotes {
+  againstVotes: BigNumber | undefined;
+  forVotes: BigNumber | undefined;
+  abstainVotes: BigNumber | undefined;
+}
+
+/**
+ * TODO
+ * @param contractId -
+ * @param proposalId -
+ * @returns
+ */
+const fetchProposalVotes = async (contractId: string, proposalId: string): Promise<ProposalVotes> => {
+  const governorContractId = ContractId.fromString(contractId);
+  const preciseProposalId = BigNumber(proposalId);
+  const queryParams = new ContractFunctionParameters().addUint256(preciseProposalId);
+  const result = await queryContract(governorContractId, GovernorContractFunctions.GetProposalVotes, queryParams);
+  const againstVotes = result?.getInt256(0);
+  const forVotes = result?.getInt256(1);
+  const abstainVotes = result?.getInt256(2);
+  return { againstVotes, forVotes, abstainVotes };
+};
 interface CastVoteParams {
   contractId: string;
-  proposalId: BigNumber;
+  proposalId: string;
   voteType: number;
   signer: HashConnectSigner;
 }
 
-const castVote = async ({ contractId, proposalId, voteType, signer }: CastVoteParams) => {
+/**
+ * TODO
+ * @param params -
+ * @returns
+ */
+const castVote = async (params: CastVoteParams) => {
+  const { contractId, proposalId, voteType, signer } = params;
   const governorContractId = ContractId.fromString(contractId);
-  const contractFunctionParameters = new ContractFunctionParameters().addUint256(proposalId).addUint8(voteType);
+  const preciseProposalId = BigNumber(proposalId);
+  const contractFunctionParameters = new ContractFunctionParameters().addUint256(preciseProposalId).addUint8(voteType);
   const castVoteTransaction = await new ContractExecuteTransaction()
     .setContractId(governorContractId)
     .setFunction(GovernorContractFunctions.CastVote, contractFunctionParameters)
     .setGas(900000)
     .freezeWithSigner(signer);
-
   const response = await castVoteTransaction.executeWithSigner(signer);
   return response;
 };
@@ -33,34 +100,85 @@ interface CreateTransferTokenProposalParams {
   signer: HashConnectSigner;
 }
 
-const sendCreateTransferTokenProposalTransaction = async ({
-  description,
-  accountToTransferTo,
-  tokenToTransfer,
-  amountToTransfer,
-  signer,
-}: CreateTransferTokenProposalParams): Promise<TransactionResponse> => {
+/**
+ * TODO
+ * @param params -
+ * @returns
+ */
+const sendCreateTransferTokenProposalTransaction = async (
+  params: CreateTransferTokenProposalParams
+): Promise<TransactionResponse> => {
+  const { description, accountToTransferTo, tokenToTransfer, amountToTransfer, signer } = params;
   const accountToTransferFrom = TREASURY_ID;
   const transferFromAddress = AccountId.fromString(accountToTransferFrom).toSolidityAddress();
   const transferToAddress = AccountId.fromString(accountToTransferTo).toSolidityAddress();
   const tokenToTransferAddress = AccountId.fromString(tokenToTransfer).toSolidityAddress();
-
   const contractCallParams = new ContractFunctionParameters()
     .addString(description)
     .addAddress(transferFromAddress)
     .addAddress(transferToAddress)
     .addAddress(tokenToTransferAddress)
     .addInt256(amountToTransfer);
-
   const createProposalTransaction = await new ContractExecuteTransaction()
     .setContractId(GovernorProxyContracts.TransferTokenContractId)
     .setFunction(GovernorContractFunctions.CreateProposal, contractCallParams)
     .setGas(9000000)
     .freezeWithSigner(signer);
-
   const proposalTransactionResponse = await createProposalTransaction.executeWithSigner(signer);
   return proposalTransactionResponse;
 };
 
-const GovernorService = { castVote, sendCreateTransferTokenProposalTransaction };
+/**
+ * TODO
+ * @param description -
+ * @param signer -
+ * @returns
+ */
+const sendCreateTextProposalTransaction = async (
+  description: string,
+  signer: HashConnectSigner
+): Promise<TransactionResponse> => {
+  const contractCallParams = new ContractFunctionParameters().addString(description);
+  const createProposalTransaction = await new ContractExecuteTransaction()
+    .setContractId(GovernorProxyContracts.TextProposalContractId)
+    .setFunction(GovernorContractFunctions.CreateProposal, contractCallParams)
+    .setGas(9000000)
+    .freezeWithSigner(signer);
+  const proposalTransactionResponse = await createProposalTransaction.executeWithSigner(signer);
+  return proposalTransactionResponse;
+};
+interface ExecuteProposalParams {
+  contractId: string;
+  description: string;
+  signer: HashConnectSigner;
+}
+
+/**
+ * TODO
+ * @param params -
+ * @returns
+ */
+const executeProposal = async (params: ExecuteProposalParams) => {
+  const { contractId, description, signer } = params;
+  const governorContractId = ContractId.fromString(contractId);
+  const contractFunctionParameters = new ContractFunctionParameters().addString(description);
+  const executeProposalTransaction = await new ContractExecuteTransaction()
+    .setContractId(governorContractId)
+    .setFunction(GovernorContractFunctions.ExecuteProposal, contractFunctionParameters)
+    .setGas(900000)
+    .freezeWithSigner(signer);
+  const executeTransactionResponse = await executeProposalTransaction.executeWithSigner(signer);
+  return executeTransactionResponse;
+};
+
+const GovernorService = {
+  fetchProposalState,
+  fetchQuorum,
+  fetchProposalVotes,
+  castVote,
+  sendCreateTextProposalTransaction,
+  sendCreateTransferTokenProposalTransaction,
+  executeProposal,
+};
+
 export default GovernorService;

--- a/src/dex-ui/services/HederaService/types.ts
+++ b/src/dex-ui/services/HederaService/types.ts
@@ -8,6 +8,7 @@ enum GovernorContractFunctions {
   GetProposalVotes = "proposalVotes",
   GetQuorum = "quorum",
   CastVote = "castVote",
+  ExecuteProposal = "executeProposal",
 }
 
 enum PairContractFunctions {

--- a/src/dex-ui/services/HederaService/utils.ts
+++ b/src/dex-ui/services/HederaService/utils.ts
@@ -1,5 +1,12 @@
-import { AccountId, PrivateKey, Client } from "@hashgraph/sdk";
 import { ADMIN_ID, ADMIN_KEY, TREASURY_ID, TREASURY_KEY, TOKEN_USER_ID, TOKEN_USER_KEY } from "../constants";
+import {
+  PrivateKey,
+  Client,
+  AccountId,
+  ContractId,
+  ContractCallQuery,
+  ContractFunctionParameters,
+} from "@hashgraph/sdk";
 
 const adminId = AccountId.fromString(ADMIN_ID);
 const adminKey = PrivateKey.fromString(ADMIN_KEY);
@@ -49,4 +56,28 @@ const createUserClient = (): Client => {
   return createClient(userId, userKey);
 };
 
-export { getAdmin, getTreasurer, getUser, createClient, createAdminClient, createTreasuryClient, createUserClient };
+const client = createUserClient();
+
+const queryContract = async (
+  contractId: ContractId,
+  functionName: string,
+  queryParams?: ContractFunctionParameters
+) => {
+  const gas = 50000;
+  const query = new ContractCallQuery().setContractId(contractId).setGas(gas).setFunction(functionName, queryParams);
+  const queryPayment = await query.getCost(client);
+  query.setMaxQueryPayment(queryPayment);
+  return await query.execute(client);
+};
+
+export {
+  client,
+  queryContract,
+  getAdmin,
+  getTreasurer,
+  getUser,
+  createClient,
+  createAdminClient,
+  createTreasuryClient,
+  createUserClient,
+};

--- a/src/dex-ui/services/MirrorNodeService/MirrorNodeService.ts
+++ b/src/dex-ui/services/MirrorNodeService/MirrorNodeService.ts
@@ -196,7 +196,10 @@ function createMirrorNodeService() {
    * @param contractId - The id of the contract to fetch events from.
    * @returns An array of proposal event data.
    */
-  const fetchAllProposals = async (contractId: string): Promise<MirrorNodeDecodedProposalEvent[]> => {
+  const fetchAllProposals = async (
+    proposalType: string,
+    contractId: string
+  ): Promise<MirrorNodeDecodedProposalEvent[]> => {
     /*
      Currently, each proposal requires multiple additional calls to the smart contract
      to get all of the desired data for the UI. This is an expensive action that costs a large
@@ -231,7 +234,7 @@ function createMirrorNodeService() {
           proposalEventLog.topics.slice(1)
         );
         return [
-          proposalCreatedEvent ? { ...proposalCreatedEvent, contractId } : undefined,
+          proposalCreatedEvent ? { ...proposalCreatedEvent, contractId, type: proposalType } : undefined,
           // decodeEvent("ProposalExecuted", proposalEventLog.data, proposalEventLog.topics.slice(1)),
           // decodeEvent("ProposalCanceled", proposalEventLog.data, proposalEventLog.topics.slice(1)),
         ];

--- a/src/dex-ui/services/MirrorNodeService/types.ts
+++ b/src/dex-ui/services/MirrorNodeService/types.ts
@@ -75,15 +75,16 @@ interface MirrorNodeProposalEventLog {
 }
 
 interface MirrorNodeDecodedProposalEvent {
-  proposalId: BigNumber;
+  proposalId: string;
   contractId: string;
+  type: string;
   proposer?: string;
   targets?: string[];
-  values?: BigNumber[];
+  values?: string[];
   signatures?: string[];
-  calldatas?: BigNumber[];
-  startBlock?: BigNumber;
-  endBlock?: BigNumber;
+  calldatas?: string[];
+  startBlock?: string;
+  endBlock?: string;
   description?: string;
 }
 

--- a/src/dex-ui/store/governanceSlice/governanceSlice.ts
+++ b/src/dex-ui/store/governanceSlice/governanceSlice.ts
@@ -1,7 +1,7 @@
 import { GovernorProxyContracts } from "./../../services/constants";
 import { BigNumber } from "bignumber.js";
-import { AccountId, ContractId } from "@hashgraph/sdk";
-import { HederaService, WalletService, MirrorNodeService, MirrorNodeDecodedProposalEvent } from "../../services";
+import { AccountId } from "@hashgraph/sdk";
+import { HederaService, MirrorNodeService, MirrorNodeDecodedProposalEvent } from "../../services";
 import { getErrorMessage } from "../../utils";
 import { TransactionStatus } from "../appSlice";
 import {
@@ -12,178 +12,14 @@ import {
   GovernanceStore,
   Proposal,
   ProposalState,
-  ProposalStatus,
+  CreateProposalData,
+  CreateTransferTokenProposalData,
+  ProposalType,
 } from "./type";
 import { getStatus } from "./utils";
 import { isNil } from "ramda";
 
 const TOTAL_GOD_TOKEN_SUPPLY = BigNumber(100);
-
-/** TODO: Replace will real data */
-const mockProposalData: Proposal[] = [
-  {
-    id: BigNumber(0),
-    contractId: GovernorProxyContracts.CreateTokenStringId,
-    title: "New Token Proposal 8",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: ProposalStatus.Active,
-    timeRemaining: BigNumber(86400),
-    state: ProposalState.Active,
-    votes: {
-      yes: new BigNumber(12),
-      no: new BigNumber(2),
-      abstain: new BigNumber(30),
-      quorum: new BigNumber(15),
-      max: TOTAL_GOD_TOKEN_SUPPLY,
-    },
-  },
-  {
-    id: BigNumber(0),
-    contractId: GovernorProxyContracts.CreateTokenStringId,
-    title: "New Token Proposal 1",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: ProposalStatus.Active,
-    timeRemaining: BigNumber(16400),
-    state: ProposalState.Active,
-    votes: {
-      yes: new BigNumber(12),
-      no: new BigNumber(2),
-      abstain: new BigNumber(30),
-      quorum: new BigNumber(15),
-      max: TOTAL_GOD_TOKEN_SUPPLY,
-    },
-  },
-  {
-    id: BigNumber(0),
-    contractId: GovernorProxyContracts.CreateTokenStringId,
-    title: "New Token Proposal 2",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: ProposalStatus.Active,
-    timeRemaining: BigNumber(66400),
-    state: ProposalState.Active,
-    votes: {
-      yes: new BigNumber(12),
-      no: new BigNumber(2),
-      abstain: new BigNumber(30),
-      quorum: new BigNumber(15),
-      max: TOTAL_GOD_TOKEN_SUPPLY,
-    },
-  },
-  {
-    id: BigNumber(0),
-    contractId: GovernorProxyContracts.CreateTokenStringId,
-    title: "New Token Proposal 5",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: ProposalStatus.Active,
-    timeRemaining: BigNumber(166400),
-    state: ProposalState.Active,
-    votes: {
-      yes: new BigNumber(12),
-      no: new BigNumber(2),
-      abstain: new BigNumber(30),
-      quorum: new BigNumber(15),
-      max: TOTAL_GOD_TOKEN_SUPPLY,
-    },
-  },
-  {
-    id: BigNumber(0),
-    contractId: GovernorProxyContracts.CreateTokenStringId,
-    title: "New Token Proposal 6",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: ProposalStatus.Passed,
-    timeRemaining: new BigNumber(0),
-    state: ProposalState.Executed,
-    votes: {
-      yes: new BigNumber(12),
-      no: new BigNumber(2),
-      abstain: new BigNumber(30),
-      quorum: new BigNumber(15),
-      max: TOTAL_GOD_TOKEN_SUPPLY,
-    },
-  },
-  {
-    id: BigNumber(0),
-    contractId: GovernorProxyContracts.CreateTokenStringId,
-    title: "New Token Proposal 9",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: ProposalStatus.Passed,
-    timeRemaining: new BigNumber(0),
-    state: ProposalState.Executed,
-    votes: {
-      yes: new BigNumber(12),
-      no: new BigNumber(2),
-      abstain: new BigNumber(30),
-      quorum: new BigNumber(15),
-      max: TOTAL_GOD_TOKEN_SUPPLY,
-    },
-  },
-  {
-    id: BigNumber(0),
-    contractId: GovernorProxyContracts.CreateTokenStringId,
-    title: "New Token Proposal 3",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-    adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: ProposalStatus.Failed,
-    timeRemaining: new BigNumber(0),
-    state: ProposalState.Defeated,
-    votes: {
-      yes: new BigNumber(12),
-      no: new BigNumber(2),
-      abstain: new BigNumber(30),
-      quorum: new BigNumber(15),
-      max: TOTAL_GOD_TOKEN_SUPPLY,
-    },
-  },
-  {
-    id: BigNumber(0),
-    contractId: GovernorProxyContracts.CreateTokenStringId,
-    title: "New Token Proposal 4",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-      adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: ProposalStatus.Failed,
-    timeRemaining: new BigNumber(0),
-    state: ProposalState.Defeated,
-    votes: {
-      yes: new BigNumber(12),
-      no: new BigNumber(2),
-      abstain: new BigNumber(30),
-      quorum: new BigNumber(15),
-      max: TOTAL_GOD_TOKEN_SUPPLY,
-    },
-  },
-  {
-    id: BigNumber(0),
-    contractId: GovernorProxyContracts.CreateTokenStringId,
-    title: "New Token Proposal 7",
-    description: `Preview of the description lorem ipsum dolor sit amit consectetur 
-        adipiscing elit Phasellus congue, sapien eu...`,
-    author: AccountId.fromString("0.0.34728121"),
-    status: ProposalStatus.Failed,
-    timeRemaining: new BigNumber(0),
-    state: ProposalState.Defeated,
-    votes: {
-      yes: new BigNumber(12),
-      no: new BigNumber(2),
-      abstain: new BigNumber(30),
-      quorum: new BigNumber(15),
-      max: TOTAL_GOD_TOKEN_SUPPLY,
-    },
-  },
-];
 
 const initialGovernanceStore: GovernanceState = {
   proposals: [],
@@ -205,18 +41,15 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
   return {
     ...initialGovernanceStore,
     castVote: async (contractId: string, proposalId: string, voteType: number) => {
-      const { context, wallet } = get();
+      const { wallet } = get();
       set(
         ({ governance }) => {
           governance.proposalTransacationState = initialGovernanceStore.proposalTransacationState;
         },
         false,
-        GovernanceActionType.SEND_VOTE_STARTED
+        GovernanceActionType.SEND_VOTE.Started
       );
-      const signingAccount = wallet.savedPairingData?.accountIds[0] ?? "";
-      const provider = WalletService.getProvider(context.network, wallet.topicID, signingAccount);
-      const signer = WalletService.getSigner(provider);
-      const preciseProposalId = BigNumber(proposalId);
+      const signer = wallet.getSigner();
       try {
         set(
           ({ governance }) => {
@@ -225,7 +58,7 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
           false,
           GovernanceActionType.SIGN_TRANSACTION
         );
-        const response = await HederaService.castVote({ contractId, proposalId: preciseProposalId, voteType, signer });
+        const response = await HederaService.castVote({ contractId, proposalId, voteType, signer });
         if (response) {
           set(
             ({ governance }) => {
@@ -233,7 +66,7 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
               governance.proposalTransacationState.successPayload.transactionResponse = response;
             },
             false,
-            GovernanceActionType.SEND_VOTE_SUCCEEDED
+            GovernanceActionType.SEND_VOTE.Succeeded
           );
         } else {
           throw new Error("Transaction Execution Failed");
@@ -246,7 +79,7 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
             governance.proposalTransacationState.errorMessage = errorMessage;
           },
           false,
-          GovernanceActionType.SEND_VOTE_FAILED
+          GovernanceActionType.SEND_VOTE.Failed
         );
       }
     },
@@ -257,54 +90,107 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
     fetchProposals: async () => {
       const { app } = get();
       app.setFeaturesAsLoading(["proposals"]);
-      set({}, false, GovernanceActionType.FETCH_PROPOSALS_STARTED);
+      set({}, false, GovernanceActionType.FETCH_PROPOSALS.Started);
+      /** TODO: Refactor and move fetchProposal logic into service layer and utils files. */
       try {
-        const proposalEvents = await MirrorNodeService.fetchAllProposals(GovernorProxyContracts.TransferTokenStringId);
-        const getTimeRemaining = (startBlock: BigNumber, endBlock: BigNumber): BigNumber => {
+        const tokenTransferEventsResult = MirrorNodeService.fetchAllProposals(
+          ProposalType.TokenTransfer,
+          GovernorProxyContracts.TransferTokenStringId
+        );
+        const createTokenEventsResult = MirrorNodeService.fetchAllProposals(
+          ProposalType.CreateToken,
+          GovernorProxyContracts.CreateTokenStringId
+        );
+        const textProposalEventsResult = MirrorNodeService.fetchAllProposals(
+          ProposalType.Text,
+          GovernorProxyContracts.TextProposalStringId
+        );
+        const contractUpgradeEventsResult = MirrorNodeService.fetchAllProposals(
+          ProposalType.ContractUpgrade,
+          GovernorProxyContracts.ContractUpgradeStringId
+        );
+
+        const proposalEventsResults = await Promise.allSettled([
+          tokenTransferEventsResult,
+          createTokenEventsResult,
+          textProposalEventsResult,
+          contractUpgradeEventsResult,
+        ]);
+
+        const proposalEvents = proposalEventsResults.reduce(
+          (
+            proposalEvents: MirrorNodeDecodedProposalEvent[],
+            proposalEventResult: PromiseSettledResult<MirrorNodeDecodedProposalEvent[]>
+          ): MirrorNodeDecodedProposalEvent[] => {
+            if (proposalEventResult.status === "fulfilled") return [...proposalEvents, ...proposalEventResult.value];
+            return proposalEvents;
+          },
+          []
+        );
+
+        const getTimeRemaining = (startBlock: string, endBlock: string): BigNumber => {
           /** Each Blocktime is about 12 secs long */
           const duration = BigNumber(endBlock).minus(BigNumber(startBlock)).times(12);
           return duration;
         };
-        const proposals = await Promise.allSettled(
+
+        const proposalDetailsResults = await Promise.allSettled(
           proposalEvents.map(async (proposalEvent: MirrorNodeDecodedProposalEvent): Promise<Proposal> => {
-            const { proposalId, contractId, description, proposer, startBlock, endBlock } = proposalEvent;
-            const state = await HederaService.fetchProposalState(proposalId);
-            const votes = await HederaService.fetchProposalVotes(proposalId);
-            const quorum = endBlock ? await HederaService.fetchQuorum(endBlock) : undefined;
-            const proposalState = state
-              ? (ContractProposalState[state?.toNumber()] as keyof typeof ContractProposalState)
-              : undefined;
-            return {
-              id: proposalId,
-              contractId,
-              title: description,
-              description: `Preview of the description lorem ipsum dolor sit amit consectetur 
+            const { proposalId, contractId, type, description, proposer, startBlock, endBlock } = proposalEvent;
+            try {
+              const stateResult = HederaService.fetchProposalState(contractId, proposalId);
+              const votesResult = HederaService.fetchProposalVotes(contractId, proposalId);
+              const quorumResult = endBlock ? HederaService.fetchQuorum(contractId, endBlock) : undefined;
+              const events = await Promise.allSettled([stateResult, votesResult, quorumResult]);
+              const [state, votes, quorum] = events.map((event: any) => {
+                return event.value ? event.value : undefined;
+              });
+              const proposalState = state
+                ? (ContractProposalState[state?.toNumber()] as keyof typeof ContractProposalState)
+                : undefined;
+              console.log([state, votes, quorum], proposalState);
+              const isProposalTypeValid = Object.values(ProposalType).includes(type as ProposalType);
+              return {
+                id: proposalId,
+                contractId,
+                type: isProposalTypeValid ? (type as ProposalType) : undefined,
+                title: description,
+                description: `Preview of the description lorem ipsum dolor sit amit consectetur 
             adipiscing elit Phasellus congue, sapien eu...`,
-              author: proposer ? AccountId.fromSolidityAddress(proposer) : AccountId.fromString("0.0.34728121"),
-              status: proposalState ? getStatus(ProposalState[proposalState]) : undefined,
-              timeRemaining:
-                !isNil(startBlock) && !isNil(endBlock) ? getTimeRemaining(startBlock, endBlock) : undefined,
-              state: proposalState ? ProposalState[proposalState as keyof typeof ProposalState] : undefined,
-              votes: {
-                yes: votes.forVotes,
-                no: votes.againstVotes,
-                abstain: votes.abstainVotes,
-                quorum,
-                max: TOTAL_GOD_TOKEN_SUPPLY,
-              },
-            };
+                author: proposer ? AccountId.fromSolidityAddress(proposer) : AccountId.fromString("0.0.34728121"),
+                status: proposalState ? getStatus(ProposalState[proposalState]) : undefined,
+                timeRemaining:
+                  !isNil(startBlock) && !isNil(endBlock) ? getTimeRemaining(startBlock, endBlock) : undefined,
+                state: proposalState ? ProposalState[proposalState as keyof typeof ProposalState] : undefined,
+                votes: {
+                  yes: votes.forVotes,
+                  no: votes.againstVotes,
+                  abstain: votes.abstainVotes,
+                  quorum,
+                  max: TOTAL_GOD_TOKEN_SUPPLY,
+                },
+              };
+            } catch (error) {
+              const errorMessage = getErrorMessage(error);
+              throw Error(errorMessage);
+            }
           })
         );
-        const fulfilledProposals = proposals.reduce((p: any, proposal: any): Proposal[] => {
-          if (proposal.status === "fulfilled") return [...p, proposal.value];
-          return p;
-        }, []);
+
+        const proposals = proposalDetailsResults.reduce(
+          (proposals: Proposal[], proposalResult: PromiseSettledResult<Proposal>): Proposal[] => {
+            console.log(proposalResult);
+            if (proposalResult.status === "fulfilled") return [...proposals, proposalResult.value];
+            return proposals;
+          },
+          []
+        );
         set(
           ({ governance }) => {
-            governance.proposals = fulfilledProposals;
+            governance.proposals = proposals;
           },
           false,
-          GovernanceActionType.FETCH_PROPOSALS_SUCCEEDED
+          GovernanceActionType.FETCH_PROPOSALS.Succeeded
         );
       } catch (error) {
         const errorMessage = getErrorMessage(error);
@@ -313,13 +199,13 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
             governance.errorMessage = errorMessage;
           },
           false,
-          GovernanceActionType.FETCH_PROPOSALS_FAILED
+          GovernanceActionType.FETCH_PROPOSALS.Failed
         );
       }
       app.setFeaturesAsLoaded(["proposals"]);
     },
-    createTransferTokenProposal: async ({ title, accountToTransferTo, tokenToTransfer, amountToTransfer }) => {
-      const { context, wallet } = get();
+    createProposal: async (type: ProposalType, data: CreateProposalData) => {
+      const { wallet } = get();
       set(
         ({ governance }) => {
           governance.proposalTransacationState = {
@@ -329,42 +215,50 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
           governance.errorMessage = initialGovernanceStore.errorMessage;
         },
         false,
-        GovernanceActionType.SEND_TRANSFER_TOKEN_PROPOSAL_STARTED
+        GovernanceActionType.SEND_CREATE_PROPOSAL.Started
       );
-      const provider = WalletService.getProvider(
-        context.network,
-        wallet.topicID,
-        wallet.savedPairingData?.accountIds[0] ?? ""
-      );
-      const signer = WalletService.getSigner(provider);
-      const preciseTransferTokenAmount = wallet.getTokenAmountWithPrecision("", amountToTransfer, tokenToTransfer);
+      const signer = wallet.getSigner();
       try {
-        const result = await HederaService.sendCreateTransferTokenProposalTransaction({
-          description: title,
-          accountToTransferTo,
-          tokenToTransfer,
-          amountToTransfer: preciseTransferTokenAmount,
-          signer,
-        });
+        const getResult = async () => {
+          if (type === ProposalType.Text) {
+            return HederaService.sendCreateTextProposalTransaction(data.title, signer);
+          }
+          if (type === ProposalType.TokenTransfer) {
+            const createTransferTokenProposalData = data as CreateTransferTokenProposalData;
+            const preciseTransferTokenAmount = wallet.getTokenAmountWithPrecision(
+              // TODO: This is a temporary override to use token id instead of symbol
+              "",
+              createTransferTokenProposalData.amountToTransfer,
+              createTransferTokenProposalData.tokenToTransfer
+            );
+            return HederaService.sendCreateTransferTokenProposalTransaction({
+              description: data.title,
+              accountToTransferTo: createTransferTokenProposalData.accountToTransferTo,
+              tokenToTransfer: createTransferTokenProposalData.tokenToTransfer,
+              amountToTransfer: preciseTransferTokenAmount,
+              signer,
+            });
+          }
+        };
+        const result = await getResult();
         if (result !== undefined) {
           set(
             ({ governance }) => {
               governance.proposalTransacationState = {
                 status: TransactionStatus.SUCCESS,
                 successPayload: {
-                  proposal: { title },
+                  proposal: { title: data.title },
                   transactionResponse: result,
                 },
                 errorMessage: "",
               };
               governance.errorMessage = initialGovernanceStore.errorMessage;
-              governance.proposals = mockProposalData;
             },
             false,
-            GovernanceActionType.SEND_TRANSFER_TOKEN_PROPOSAL_SUCCEEDED
+            GovernanceActionType.SEND_CREATE_PROPOSAL.Succeeded
           );
         } else {
-          throw new Error(`Create transfer token proposal failed`);
+          throw new Error(`Create proposal failed`);
         }
       } catch (error) {
         const errorMessage = getErrorMessage(error);
@@ -378,76 +272,7 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
             governance.errorMessage = errorMessage;
           },
           false,
-          GovernanceActionType.SEND_TRANSFER_TOKEN_PROPOSAL_FAILED
-        );
-      }
-    },
-    sendCreateNewTokenProposalTransaction: async ({ title }) => {
-      const { context, wallet } = get();
-      const { network } = context;
-      set(
-        ({ governance }) => {
-          governance.proposalTransacationState = {
-            ...initialGovernanceStore.proposalTransacationState,
-            status: TransactionStatus.IN_PROGRESS,
-          };
-          governance.errorMessage = initialGovernanceStore.errorMessage;
-        },
-        false,
-        GovernanceActionType.SEND_CREATE_NEW_TOKEN_PROPOSAL_STARTED
-      );
-      const provider = WalletService.getProvider(network, wallet.topicID, wallet.savedPairingData?.accountIds[0] ?? "");
-      const signer = WalletService.getSigner(provider);
-      /**
-       * All data except for the proposal title is mocked for now. The proposal execution
-       * logic should be computed on the Hedera network in a Smart Contract - not on the front-end.
-       * */
-      const mockContractAddress = ContractId.fromString("0.0.48585457").toSolidityAddress();
-      const targets = [mockContractAddress];
-      const fees = [0];
-      const associateToken = new Uint8Array([255]);
-      const calls = [associateToken];
-      try {
-        const result = await HederaService.createProposal({
-          targets,
-          fees,
-          calls,
-          description: title,
-          signer,
-        });
-        if (result !== undefined) {
-          set(
-            ({ governance }) => {
-              governance.proposalTransacationState = {
-                status: TransactionStatus.SUCCESS,
-                successPayload: {
-                  proposal: { title },
-                  transactionResponse: result,
-                },
-                errorMessage: "",
-              };
-              governance.errorMessage = initialGovernanceStore.errorMessage;
-              governance.proposals = mockProposalData;
-            },
-            false,
-            GovernanceActionType.SEND_CREATE_NEW_TOKEN_PROPOSAL_SUCCEEDED
-          );
-        } else {
-          throw new Error(`Create new proposal execution failed`);
-        }
-      } catch (error) {
-        const errorMessage = getErrorMessage(error);
-        set(
-          ({ governance }) => {
-            governance.proposalTransacationState = {
-              status: TransactionStatus.ERROR,
-              successPayload: initialGovernanceStore.proposalTransacationState.successPayload,
-              errorMessage: errorMessage,
-            };
-            governance.errorMessage = errorMessage;
-          },
-          false,
-          GovernanceActionType.SEND_CREATE_NEW_TOKEN_PROPOSAL_FAILED
+          GovernanceActionType.SEND_CREATE_PROPOSAL.Failed
         );
       }
     },
@@ -460,6 +285,59 @@ const createGovernanceSlice: GovernanceSlice = (set, get): GovernanceStore => {
         false,
         GovernanceActionType.CLEAR_PROPOSAL_TRANSACTION_STATE
       );
+    },
+    executeProposal: async (contractId: string, title: string) => {
+      const { wallet } = get();
+      set(
+        ({ governance }) => {
+          governance.proposalTransacationState = {
+            ...initialGovernanceStore.proposalTransacationState,
+            status: TransactionStatus.IN_PROGRESS,
+          };
+          governance.errorMessage = initialGovernanceStore.errorMessage;
+        },
+        false,
+        GovernanceActionType.EXECUTE_PROPOSAL.Started
+      );
+      const signer = wallet.getSigner();
+
+      try {
+        const result = await HederaService.executeProposal({ contractId, description: title, signer });
+
+        if (result !== undefined) {
+          set(
+            ({ governance }) => {
+              governance.proposalTransacationState = {
+                status: TransactionStatus.SUCCESS,
+                successPayload: {
+                  proposal: { title },
+                  transactionResponse: result,
+                },
+                errorMessage: "",
+              };
+              governance.errorMessage = initialGovernanceStore.errorMessage;
+            },
+            false,
+            GovernanceActionType.EXECUTE_PROPOSAL.Succeeded
+          );
+        } else {
+          throw new Error(`Execute proposal failed`);
+        }
+      } catch (error) {
+        const errorMessage = getErrorMessage(error);
+        set(
+          ({ governance }) => {
+            governance.proposalTransacationState = {
+              status: TransactionStatus.ERROR,
+              successPayload: initialGovernanceStore.proposalTransacationState.successPayload,
+              errorMessage: errorMessage,
+            };
+            governance.errorMessage = errorMessage;
+          },
+          false,
+          GovernanceActionType.EXECUTE_PROPOSAL.Failed
+        );
+      }
     },
   };
 };

--- a/src/dex-ui/store/governanceSlice/type.ts
+++ b/src/dex-ui/store/governanceSlice/type.ts
@@ -4,6 +4,13 @@ import { StateCreator } from "zustand";
 import { DEXState } from "..";
 import { TransactionStatus } from "../appSlice";
 
+enum ProposalType {
+  Text = "Text",
+  TokenTransfer = "Token Transfer",
+  CreateToken = "Create Token",
+  ContractUpgrade = "Contract Upgrade",
+}
+
 enum ProposalStatus {
   Active = "Active",
   Passed = "Passed",
@@ -36,8 +43,9 @@ enum ProposalState {
 }
 
 interface Proposal {
-  id: BigNumber;
+  id: string;
   contractId: string;
+  type: ProposalType | undefined;
   title: string | undefined;
   author: AccountId;
   description: string;
@@ -53,28 +61,38 @@ interface Proposal {
   };
 }
 
-enum GovernanceActionType {
-  FETCH_PROPOSALS_STARTED = "governance/FETCH_PROPOSALS_STARTED",
-  FETCH_PROPOSALS_SUCCEEDED = "governance/FETCH_PROPOSALS_SUCCEEDED",
-  FETCH_PROPOSALS_FAILED = "governance/FETCH_PROPOSALS_FAILED",
-  SEND_TRANSFER_TOKEN_PROPOSAL_STARTED = "governance/SEND_TRANSFER_TOKEN_PROPOSAL_STARTED",
-  SEND_TRANSFER_TOKEN_PROPOSAL_SUCCEEDED = "governance/SEND_TRANSFER_TOKEN_PROPOSAL_SUCCEEDED",
-  SEND_TRANSFER_TOKEN_PROPOSAL_FAILED = "governance/SEND_TRANSFER_TOKEN_PROPOSAL_FAILED",
-  SEND_CREATE_NEW_TOKEN_PROPOSAL_STARTED = "governance/SEND_CREATE_NEW_TOKEN_PROPOSAL_STARTED",
-  SEND_CREATE_NEW_TOKEN_PROPOSAL_SUCCEEDED = "governance/SEND_CREATE_NEW_TOKEN_PROPOSAL_SUCCEEDED",
-  SEND_CREATE_NEW_TOKEN_PROPOSAL_FAILED = "governance/SEND_CREATE_NEW_TOKEN_PROPOSAL_FAILED",
-  SEND_CONTRACT_UPGRADE_PROPOSAL_STARTED = "governance/SEND_CONTRACT_UPGRADE_PROPOSAL_STARTED",
-  SEND_CONTRACT_UPGRADE_PROPOSAL_SUCCEEDED = "governance/SEND_CONTRACT_UPGRADE_PROPOSAL_SUCCEEDED",
-  SEND_CONTRACT_UPGRADE_PROPOSAL_FAILED = "governance/SEND_CONTRACT_UPGRADE_PROPOSAL_FAILED",
-  SEND_TEXT_PROPOSAL_STARTED = "governance/SEND_TEXT_PROPOSAL_STARTED",
-  SEND_TEXT_PROPOSAL_SUCCEEDED = "governance/SEND_TEXT_PROPOSAL_SUCCEEDED",
-  SEND_TEXT_PROPOSAL_FAILED = "governance/SEND_TEXT_PROPOSAL_FAILED",
-  SEND_VOTE_STARTED = "governance/SEND_VOTE_STARTED",
-  SEND_VOTE_SUCCEEDED = "governance/SEND_VOTE_SUCCEEDED",
-  SEND_VOTE_FAILED = "governance/SEND_VOTE_FAILED",
-  SIGN_TRANSACTION = "governance/SIGN_TRANSACTION",
-  CLEAR_PROPOSAL_TRANSACTION_STATE = "governance/CLEAR_PROPOSAL_TRANSACTION_STATE",
+enum FETCH_PROPOSALS {
+  Started = "governance/FETCH_PROPOSALS_Started",
+  Succeeded = "governance/FETCH_PROPOSALS_Succeeded",
+  Failed = "governance/FETCH_PROPOSALS_Failed",
 }
+
+enum EXECUTE_PROPOSAL {
+  Started = "governance/EXECUTE_PROPOSAL_Started",
+  Succeeded = "governance/EXECUTE_PROPOSAL_Succeeded",
+  Failed = "governance/EXECUTE_PROPOSAL_Failed",
+}
+
+enum SEND_CREATE_PROPOSAL {
+  Started = "governance/SEND_CREATE_PROPOSAL_Started",
+  Succeeded = "governance/SEND_CREATE_PROPOSAL_Succeeded",
+  Failed = "governance/SEND_CREATE_PROPOSALL_Failed",
+}
+
+enum SEND_VOTE {
+  Started = "governance/SEND_VOTE_Started",
+  Succeeded = "governance/SEND_VOTE_Succeeded",
+  Failed = "governance/SEND_VOTE_Failed",
+}
+
+const GovernanceActionType = {
+  FETCH_PROPOSALS,
+  EXECUTE_PROPOSAL,
+  SEND_CREATE_PROPOSAL,
+  SEND_VOTE,
+  SIGN_TRANSACTION: "governance/SIGN_TRANSACTION",
+  CLEAR_PROPOSAL_TRANSACTION_STATE: "governance/CLEAR_PROPOSAL_TRANSACTION_STATE",
+};
 
 interface ProposalTransacationState {
   status: TransactionStatus;
@@ -93,24 +111,29 @@ interface GovernanceState {
   proposalTransacationState: ProposalTransacationState;
 }
 
-interface sendCreateNewTokenProposalParams {
+interface CreateNewTokenProposalData {
   title: string;
 }
 
-interface CreateTransferTokenProposalActionParams {
+interface CreateTextProposalData {
+  title: string;
+}
+
+interface CreateTransferTokenProposalData {
   title: string;
   accountToTransferTo: string;
   tokenToTransfer: string;
   amountToTransfer: number;
 }
 
+type CreateProposalData = CreateNewTokenProposalData | CreateTextProposalData | CreateTransferTokenProposalData;
 interface GovernanceActions {
   castVote: (contractId: string, proposalId: string, voteType: number) => Promise<void>;
   fetchProposal: (proposalId: string) => Proposal | undefined;
   fetchProposals: () => Promise<void>;
-  createTransferTokenProposal: (params: CreateTransferTokenProposalActionParams) => Promise<void>;
-  sendCreateNewTokenProposalTransaction: ({ title }: sendCreateNewTokenProposalParams) => Promise<void>;
+  createProposal: (type: ProposalType, data: CreateProposalData) => Promise<void>;
   clearProposalTransactionState: () => void;
+  executeProposal: (contractId: string, title: string) => Promise<void>;
 }
 
 type GovernanceStore = GovernanceState & GovernanceActions;
@@ -122,5 +145,13 @@ type GovernanceSlice = StateCreator<
   GovernanceStore
 >;
 
-export { GovernanceActionType, ContractProposalState, ProposalState, ProposalStatus };
-export type { GovernanceSlice, GovernanceStore, GovernanceState, GovernanceActions, Proposal };
+export { GovernanceActionType, ProposalType, ContractProposalState, ProposalState, ProposalStatus };
+export type {
+  CreateProposalData,
+  CreateTransferTokenProposalData,
+  GovernanceSlice,
+  GovernanceStore,
+  GovernanceState,
+  GovernanceActions,
+  Proposal,
+};

--- a/src/dex-ui/store/walletSlice/types.ts
+++ b/src/dex-ui/store/walletSlice/types.ts
@@ -1,3 +1,4 @@
+import { HashConnectSigner } from "hashconnect/dist/esm/provider/signer";
 import { HashConnectTypes, MessageTypes } from "hashconnect";
 import { BigNumber } from "bignumber.js";
 import { DEXState } from "../createDEXStore";
@@ -46,6 +47,7 @@ interface WalletState {
 }
 
 interface WalletActions {
+  getSigner: () => HashConnectSigner;
   getTokenAmountWithPrecision: (tokenSymbol: string, tokenAmount: number, tokenId?: string) => BigNumber;
   connectToWallet: () => void;
   disconnectWallet: () => void;

--- a/src/dex-ui/store/walletSlice/walletSlice.ts
+++ b/src/dex-ui/store/walletSlice/walletSlice.ts
@@ -23,6 +23,16 @@ const initialWalletState: WalletState = {
 const createWalletSlice: WalletSlice = (set, get): WalletStore => {
   return {
     ...initialWalletState,
+    getSigner: () => {
+      const { context, wallet } = get();
+      const provider = WalletService.getProvider(
+        context.network,
+        wallet.topicID,
+        wallet.savedPairingData?.accountIds[0] ?? ""
+      );
+      const signer = WalletService.getSigner(provider);
+      return signer;
+    },
     getTokenAmountWithPrecision: (tokenSymbol: string, tokenAmount: number, tokenId?: string) => {
       const defaultDecimals = 0;
       const { wallet } = get();


### PR DESCRIPTION
**Description**:

- Updated `Text Proposal ` form UI. Can create text proposal with new `GovernorTextProposal` contract.
- Added Cancel button to `Create Proposal` forms.
- Proposal type tag added to `All Proposals` list and `Proposal Details` page.
- Added logic to fetch proposals across all proposal contract types.
- Updated `HederaService` functions to match new proposal proxy contract functions.
- Added `Execute` button and execute functionality `Proposal Details` page. Note: The full `execute` UI flow and functionality will be merged in subsequent PR. The execute contract call currently fails with a "Transfer token failed." error - similar to the issue we're seeing with `swapToken` calls.

**Screenshots**
![Screen Shot 2022-12-14 at 9 09 41 PM](https://user-images.githubusercontent.com/54907098/207755895-50adcd61-5216-4334-a145-77fd7289f25d.png)
![Screen Shot 2022-12-14 at 9 00 08 PM](https://user-images.githubusercontent.com/54907098/207754792-0fca4016-3c58-4523-ac90-4198961e146a.png)
![Screen Shot 2022-12-14 at 9 00 26 PM](https://user-images.githubusercontent.com/54907098/207754860-886f774a-c344-4d4b-a166-5dd0eb5d6176.png)
