### PR TITLE
feat: US33917 Re-enabled proposal fetching for all proposal types

### DIFF
--- a/src/dex-ui/services/MirrorNodeService/MirrorNodeService.ts
+++ b/src/dex-ui/services/MirrorNodeService/MirrorNodeService.ts
@@ -23,6 +23,7 @@ import {
 } from "./types";
 import { ProposalType } from "../../store/governanceSlice";
 import { governorAbiSignatureMap } from "./constants";
+import { getFulfilledResultsData } from "./utils";
 
 const web3 = new Web3();
 
@@ -224,39 +225,6 @@ function createMirrorNodeService() {
     const proposals: MirrorNodeDecodedProposalEvent[] = proposalCreatedEvents.map((item: any) => {
       return { ...item, contractId, type: proposalType };
     });
-    // const proposals: MirrorNodeDecodedProposalEvent[] = response.data.logs
-    //   .flatMap((proposalEventLog: MirrorNodeProposalEventLog) => {
-    //     const proposalCreatedEvent = decodeEvent(
-    //       "ProposalCreated",
-    //       proposalEventLog.data,
-    //       proposalEventLog.topics.slice(1)
-    //     );
-    //     /* TODO: Fix claim, executed, and canceled event logs. This may need to be addressed in the
-    //     contracts code.
-    //     const godTokenClaimedEvent = decodeEvent(
-    //       "GodTokenClaimed",
-    //       proposalEventLog.data,
-    //       proposalEventLog.topics.slice(1)
-    //     );
-    //     let areGODTokensClaimed = false;
-    //     if (Boolean(godTokenClaimedEvent?.proposalId) && Boolean(proposalCreatedEvent?.proposalId))
-    //       areGODTokensClaimed = godTokenClaimedEvent?.proposalId === proposalCreatedEvent?.proposalId;
-
-    //     const proposalExecutedEvent = decodeEvent(
-    //       "ProposalExecuted",
-    //       proposalEventLog.data,
-    //       proposalEventLog.topics.slice(1)
-    //     );
-    //     const proposalCanceledEvent = decodeEvent(
-    //       "ProposalCanceled",
-    //       proposalEventLog.data,
-    //       proposalEventLog.topics.slice(1)
-    //     );
-    //     console.log(proposalCreatedEvent, godTokenClaimedEvent, proposalExecutedEvent, proposalCanceledEvent);
-    //     */
-    //     return [proposalCreatedEvent ? { ...proposalCreatedEvent, contractId, type: proposalType } : undefined];
-    //   })
-    //   .filter((proposal: MirrorNodeDecodedProposalEvent | undefined) => proposal !== undefined);
     return proposals;
   };
 
@@ -272,7 +240,6 @@ function createMirrorNodeService() {
       ProposalType.TokenTransfer,
       GovernorProxyContracts.TransferTokenStringId
     );
-    /* TODO: Enable event fetching for all proposal types.   
     const createTokenEventsResults = fetchContractProposalEvents(
       ProposalType.CreateToken,
       GovernorProxyContracts.CreateTokenStringId
@@ -284,26 +251,14 @@ function createMirrorNodeService() {
     const contractUpgradeEventsResults = fetchContractProposalEvents(
       ProposalType.ContractUpgrade,
       GovernorProxyContracts.ContractUpgradeStringId
-    ); 
-    */
+    );
     const proposalEventsResults = await Promise.allSettled([
       tokenTransferEventsResults,
-      /*      
       createTokenEventsResults,
       textProposalEventsResults,
-      contractUpgradeEventsResults, 
-      */
+      contractUpgradeEventsResults,
     ]);
-    const proposalEvents = proposalEventsResults.reduce(
-      (
-        proposalEvents: MirrorNodeDecodedProposalEvent[],
-        proposalEventResult: PromiseSettledResult<MirrorNodeDecodedProposalEvent[]>
-      ): MirrorNodeDecodedProposalEvent[] => {
-        if (proposalEventResult.status === "fulfilled") return [...proposalEvents, ...proposalEventResult.value];
-        return proposalEvents;
-      },
-      []
-    );
+    const proposalEvents = getFulfilledResultsData<MirrorNodeDecodedProposalEvent>(proposalEventsResults);
     return proposalEvents;
   };
 

--- a/src/dex-ui/services/MirrorNodeService/constants.ts
+++ b/src/dex-ui/services/MirrorNodeService/constants.ts
@@ -1,13 +1,15 @@
 import governorAbi from "../abi/GovernorCountingSimpleInternal.json";
 import Web3 from "web3";
+import { EventAbi } from "../abi/types";
 
 const web3 = new Web3();
 const governorAbiSignatureMap = loadGovernorAbiEventSignatures();
 
 function loadGovernorAbiEventSignatures() {
-  const governorAbiSignatureMap = new Map<string, any>();
-  governorAbi.abi.forEach((eventAbi: any) => {
-    if (eventAbi.type === "event") {
+  const governorAbiSignatureMap = new Map<string, EventAbi>();
+  governorAbi.abi.forEach((abi: any) => {
+    if (abi.type === "event") {
+      const eventAbi = abi as EventAbi;
       const signature = web3.eth.abi.encodeEventSignature(eventAbi);
       governorAbiSignatureMap.set(signature, eventAbi);
     }

--- a/src/dex-ui/services/MirrorNodeService/utils.ts
+++ b/src/dex-ui/services/MirrorNodeService/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Gathers all values from an array of fulfilled settled promise results.
+ * @param promiseSettledResults - An array of settled promise results. Intended to come from
+ * a Promise.allSettled call.
+ * @returns An array of values from the fulfilled promises.
+ */
+export function getFulfilledResultsData<T>(promiseSettledResults: Array<PromiseSettledResult<T[]>>): T[] {
+  return promiseSettledResults.reduce((values: T[], promiseSettledResult: PromiseSettledResult<T[]>): T[] => {
+    if (promiseSettledResult.status === "fulfilled") return [...values, ...promiseSettledResult.value];
+    return values;
+  }, []);
+}

--- a/src/dex-ui/services/abi/types.ts
+++ b/src/dex-ui/services/abi/types.ts
@@ -1,0 +1,8 @@
+type GovernanceEventNames = "ProposalCreated" | "ProposalExecuted" | "ProposalCanceled";
+
+export interface EventAbi {
+  type: "event";
+  anonymous: boolean;
+  name: GovernanceEventNames;
+  inputs: Array<any>;
+}


### PR DESCRIPTION
**Description**:
- Fetching all proposal types in governance proposal list with new event log decoding logic.

**Tech Notes**
- Added `getFulfilledResultsData` utility function to filter results from `Promise.allSettled`.

**Screenshots**
![Screen Shot 2022-12-23 at 2 02 33 PM](https://user-images.githubusercontent.com/54907098/209395031-6fdab399-e9b2-4217-b838-ea79a2f045a1.png)
![Screen Shot 2022-12-23 at 2 02 45 PM](https://user-images.githubusercontent.com/54907098/209395049-9cfe884f-d75b-4429-a310-b4718f690ebd.png)