### PR TITLE
Feat: Removed Private key dependencies from Transactions (swap, withdraw)

### DIFF
--- a/src/dex-ui/services/HederaService/GovernorService.ts
+++ b/src/dex-ui/services/HederaService/GovernorService.ts
@@ -6,12 +6,12 @@ import {
   ContractFunctionParameters,
   TransactionResponse,
   FileCreateTransaction,
-  PrivateKey,
+  PublicKey,
   ContractCreateTransaction,
   FileAppendTransaction,
 } from "@hashgraph/sdk";
 import { ContractId } from "@hashgraph/sdk";
-import { GovernorProxyContracts, TOKEN_USER_KEY } from "../constants";
+import { GovernorProxyContracts, TOKEN_USER_PUB_KEY } from "../constants";
 import { GovernorContractFunctions } from "./types";
 import { HashConnectSigner } from "hashconnect/dist/esm/provider/signer";
 import { checkTransactionResponseForError, queryContract, client } from "./utils";
@@ -311,7 +311,7 @@ const sendClaimGODTokenTransaction = async (params: SendClaimGODTokenTransaction
 const deployABIFile = async (abiFile: string) => {
   const compiledContract = JSON.parse(abiFile);
   const contractByteCode = compiledContract.bytecode;
-  const userKey = PrivateKey.fromString(TOKEN_USER_KEY);
+  const userKey = PublicKey.fromString(TOKEN_USER_PUB_KEY);
 
   const fileCreateTx = await new FileCreateTransaction().setKeys([userKey]).execute(client);
   const fileCreateRx = await fileCreateTx.getReceipt(client);

--- a/src/dex-ui/services/HederaService/HederaService.ts
+++ b/src/dex-ui/services/HederaService/HederaService.ts
@@ -8,7 +8,6 @@ import {
   TransferTransaction,
   TokenAssociateTransaction,
   TransactionResponse,
-  PrivateKey,
 } from "@hashgraph/sdk";
 import {
   GovernorProxyContracts,
@@ -18,7 +17,6 @@ import {
   TOKEN_B_ID,
   TOKEN_SYMBOL_TO_ACCOUNT_ID,
   FACTORY_CONTRACT_ID,
-  TOKEN_USER_KEY,
 } from "../constants";
 import { AddLiquidityDetails, GovernorContractFunctions, PairContractFunctions } from "./types";
 import { HashConnectSigner } from "hashconnect/dist/esm/provider/signer";
@@ -107,13 +105,11 @@ function createHederaService() {
     console.log(`Removing ${lpTokenAmount} units of LP from the pool.`);
     const removeLiquidity = await new ContractExecuteTransaction()
       .setContractId(contractId)
-      .setGas(2000000)
+      .setGas(5000000)
       .setFunction("removeLiquidity", new ContractFunctionParameters().addAddress(accountId).addInt256(lpTokenAmount))
       .freezeWithSigner(signer);
-    const key = PrivateKey.fromString(TOKEN_USER_KEY);
-    const firstSignedTrasaction = await removeLiquidity.sign(key);
-    const removeLiquidityTx = await firstSignedTrasaction.executeWithSigner(signer);
 
+    const removeLiquidityTx = await removeLiquidity.executeWithSigner(signer);
     console.log(`Liquidity remove Tx: ${removeLiquidityTx}`);
     return removeLiquidityTx;
   };
@@ -147,12 +143,10 @@ function createHederaService() {
     const swapTokenTransaction = await new ContractExecuteTransaction()
       .setContractId(contractId)
       .setFunction(PairContractFunctions.SwapToken, contractFunctionParams)
-      .setGas(2000000)
+      .setGas(9000000)
       .setNodeAccountIds([new AccountId(3)])
       .freezeWithSigner(signer);
-    const key = PrivateKey.fromString(TOKEN_USER_KEY);
-    const secondSignedTrasaction = await swapTokenTransaction.sign(key);
-    const swapTokenResponse = await secondSignedTrasaction.executeWithSigner(signer);
+    const swapTokenResponse = await swapTokenTransaction.executeWithSigner(signer);
     return swapTokenResponse;
   };
 

--- a/src/dex-ui/services/constants.ts
+++ b/src/dex-ui/services/constants.ts
@@ -12,6 +12,8 @@ export const TREASURY_ID = "0.0.47645191";
 
 export const TREASURY_KEY = "308ed38983d9d20216d00371e174fe2d475dd32ac1450ffe2edfaab782b32fc5";
 
+export const TOKEN_USER_PUB_KEY = "3e0f62c7c812d0c9d1d045c4efb70369d69549914455370adab22207ec37d967";
+
 export const CONTRACT_NAME = "governorcountingsimpleinternal";
 
 export const TOKEN_USER_ID = "0.0.47540202";
@@ -20,7 +22,7 @@ export const TOKEN_USER_KEY =
   "302e020100300506032b657004220420b69079b0cdebea97ec13c78bf7277d3f4aef35189755b5d11c2dfae40c566aa8";
 
 // Factory Contract Proxy
-export const FACTORY_CONTRACT_ID = "0.0.49207069";
+export const FACTORY_CONTRACT_ID = "0.0.49271021";
 // Swap Contract (Pair) Proxy
 export const SWAP_CONTRACT_ID = "0.0.48660596";
 


### PR DESCRIPTION
In this PR:

From Backend we changed the approach from HTS to ERC20 to transfer the token which does not require Private key for transferring tokens, based on which we do not require the sign the transaction second time using Dex Private key in UI.

Signed-off-by: Roshan Singh Bisht <roshan.bisht@lab49.com>


