### PR TITLE
fix: Partial fix for undefined vote counts (when vote fetching fails)

### DIFF
--- a/src/dex-ui/services/DexService/DexService.ts
+++ b/src/dex-ui/services/DexService/DexService.ts
@@ -62,9 +62,9 @@ function createDexService() {
       state: proposalState ? ProposalState[proposalState as keyof typeof ProposalState] : undefined,
       timestamp: proposalEvent.timestamp,
       votes: {
-        yes: proposalEvent.votes.forVotes,
-        no: proposalEvent.votes.againstVotes,
-        abstain: proposalEvent.votes.abstainVotes,
+        yes: proposalEvent.votes?.forVotes,
+        no: proposalEvent.votes?.againstVotes,
+        abstain: proposalEvent.votes?.abstainVotes,
         quorum: proposalEvent.quorum,
         max: !isNil(totalGodTokenSupply) ? new BigNumber(totalGodTokenSupply.toString()) : BigNumber(0),
       },


### PR DESCRIPTION
**Fixes**
- Partial fix for the "undefined votes" error on the governance page. The unsuccessful fetching of proposal voting data causes this error.

