### PR TITLE
Fix: Pairs not visible in prod

### DIFF
--- a/src/dex-ui/services/contractsUAT.json
+++ b/src/dex-ui/services/contractsUAT.json
@@ -87,7 +87,7 @@
     "timestamp": "2023-02-21T07:28:48.245Z",
     "hash": "2aa0ae048dc8f7830b648fc9811bde1f",
     "transparentProxyAddress": "0x000000000000000000000000000000000035e97b",
-    "transparentProxyId": "0.0.3533179"
+    "transparentProxyId": "0.0.3875898"
   },
   {
     "name": "pair",


### PR DESCRIPTION
Even with this change user will only be able to use the Swap from existing Pool this is due to the recent change is `Spot Price` SC function in Pair. Earlier we used to pass the `pairId` now with the latest change function requires the `tokenId` to get the spot price.

User wont be able to:
`Add Liquidity` `Withdraw`

The Fix for this will come is later PR's