### PR TITLE
chore: Added Path Aliases

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require(`path`);
+
 module.exports = {
   stories: ["../src/dex-ui-components/**/*.stories.mdx", "../src/dex-ui-components/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: [
@@ -12,4 +14,21 @@ module.exports = {
     builder: "@storybook/builder-webpack5",
   },
   features: { emotionAlias: false },
+  webpackFinal: async (config) => {
+    config.resolve.alias = {
+      "@dex-ui": path.resolve(__dirname, "../src/dex-ui"),
+      "@components": path.resolve(__dirname, "../src/dex-ui/components"),
+      "@context": path.resolve(__dirname, "../src/dex-ui/context"),
+      "@hooks": path.resolve(__dirname, "../src/dex-ui/hooks"),
+      "@layouts": path.resolve(__dirname, "../src/dex-ui/layouts"),
+      "@pages": path.resolve(__dirname, "../src/dex-ui/pages"),
+      "@services": path.resolve(__dirname, "../src/dex-ui/services"),
+      "@store": path.resolve(__dirname, "../src/dex-ui/store"),
+      "@theme": path.resolve(__dirname, "../src/dex-ui/theme"),
+      "@routes": path.resolve(__dirname, "../src/dex-ui/routes"),
+      "@utils": path.resolve(__dirname, "../src/dex-ui/utils"),
+      "@dex-ui-components": path.resolve(__dirname, "../src/dex-ui-components"),
+    };
+    return config;
+  },
 };

--- a/craco.config.js
+++ b/craco.config.js
@@ -1,0 +1,20 @@
+const path = require(`path`);
+
+module.exports = {
+  webpack: {
+    alias: {
+      "@dex-ui": path.resolve(__dirname, "src/dex-ui"),
+      "@components": path.resolve(__dirname, "src/dex-ui/components"),
+      "@context": path.resolve(__dirname, "src/dex-ui/context"),
+      "@hooks": path.resolve(__dirname, "src/dex-ui/hooks"),
+      "@layouts": path.resolve(__dirname, "src/dex-ui/layouts"),
+      "@pages": path.resolve(__dirname, "src/dex-ui/pages"),
+      "@services": path.resolve(__dirname, "src/dex-ui/services"),
+      "@store": path.resolve(__dirname, "src/dex-ui/store"),
+      "@theme": path.resolve(__dirname, "src/dex-ui/theme"),
+      "@routes": path.resolve(__dirname, "src/dex-ui/routes"),
+      "@utils": path.resolve(__dirname, "src/dex-ui/utils"),
+      "@dex-ui-components": path.resolve(__dirname, "src/dex-ui-components"),
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "zustand": "^4.1.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --coverage",
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test --coverage",
     "test:jest": "jest -c jest.config.js --watch",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 6006 -s public",
@@ -161,6 +161,7 @@
     "@typescript-eslint/eslint-plugin": "^5.30.6",
     "@typescript-eslint/parser": "^5.30.6",
     "babel-plugin-named-exports-order": "^0.0.2",
+    "craco": "^0.0.3",
     "eslint": "^8.19.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-react-app": "^7.0.1",

--- a/src/dex-ui/DEX.tsx
+++ b/src/dex-ui/DEX.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
-import { ChakraProvider, Container, extendTheme, Flex } from "@chakra-ui/react";
+import { ChakraProvider, Container, Flex } from "@chakra-ui/react";
 import {
   SwapPage,
   AddLiquidityPage,
@@ -14,52 +14,17 @@ import {
   DAOsListPage,
   CreateADAOPage,
   DAODetailsPage,
-} from "./pages";
-import { TopMenuBar } from "./layouts";
-import {
-  ButtonStyles,
-  CardStyles,
-  InputStyles,
-  NumberInputStyles,
-  TextStyles,
-  SelectStyles,
-  TooltipStyles,
-  StepsV2Theme,
-  Color,
-} from "../dex-ui-components";
+} from "@pages";
+import { TopMenuBar } from "@layouts";
+import { Color } from "@dex-ui-components";
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
-import { useWalletConnection } from "./hooks";
-import { ScrollToTop } from "./utils";
+import { useWalletConnection } from "@hooks";
+import { ScrollToTop } from "@utils";
+import { DEXTheme } from "@theme";
+import { Paths } from "@routes";
 
 const menuOptions = ["Swap", "Pools", "Governance", "DAOs"];
 const SEVEN_SECONDS = 7 * 1000;
-
-export const Paths = {
-  Home: "/",
-  Swap: {
-    default: "/swap",
-  },
-  Pools: {
-    default: "/pools",
-    AddLiquidity: "/pools/add-liquidity",
-    Withdraw: "/pools/withdraw",
-    CreatePool: "/pools/create-pool",
-  },
-  Governance: {
-    default: "/governance",
-    ProposalDetails: "/governance/proposal-details",
-    SelectProposalType: "/governance/select-proposal-type",
-    CreateNewToken: "/governance/select-proposal-type/new-token",
-    CreateText: "/governance/select-proposal-type/text",
-    CreateTokenTransfer: "/governance/select-proposal-type/token-transfer",
-    CreateContractUpgrade: "/governance/select-proposal-type/contract-upgrade",
-  },
-  DAOs: {
-    default: "/daos",
-    CreateDAO: "/daos/create",
-    DAODetails: "/dao",
-  },
-};
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -76,26 +41,6 @@ const queryClient = new QueryClient({
        */
       staleTime: SEVEN_SECONDS,
     },
-  },
-});
-
-export const DEXTheme = extendTheme({
-  styles: {
-    global: {
-      body: {
-        background: Color.Primary_Bg,
-      },
-    },
-  },
-  textStyles: TextStyles,
-  components: {
-    Button: ButtonStyles,
-    NumberInput: NumberInputStyles,
-    Input: InputStyles,
-    Card: CardStyles,
-    Select: SelectStyles,
-    Tooltip: TooltipStyles,
-    Steps: StepsV2Theme,
   },
 });
 

--- a/src/dex-ui/pages/dao/CreateADAO/CreateADAOPage.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/CreateADAOPage.tsx
@@ -1,8 +1,8 @@
 import { Button, Flex, Spacer, Text } from "@chakra-ui/react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useSteps } from "chakra-ui-steps";
-import { Color, LoadingDialog, StepperV2 } from "../../../../dex-ui-components";
-import { Page } from "../../../layouts";
+import { Color, LoadingDialog, StepperV2 } from "@dex-ui-components";
+import { Page } from "@layouts";
 import {
   DAODetailsForm,
   DAOTypeForm,
@@ -15,11 +15,11 @@ import {
 } from "./forms";
 import { useNavigate } from "react-router-dom";
 import { CreateADAOForm, CreateAMultiSigDAOForm, CreateATokenDAOForm } from "./types";
-import { useCreateDAO } from "../../../hooks";
+import { useCreateDAO } from "@hooks";
 import { WarningIcon } from "@chakra-ui/icons";
 import { TransactionResponse } from "@hashgraph/sdk";
-import { Paths } from "../../../DEX";
-import { DAOType } from "../../../services";
+import { Paths } from "@routes";
+import { DAOType } from "@services";
 
 export function CreateADAOPage() {
   const stepProps = useSteps({

--- a/src/dex-ui/pages/dao/CreateADAO/forms/DAODetailsForm.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/DAODetailsForm.tsx
@@ -1,6 +1,6 @@
 import { Checkbox, FormControl } from "@chakra-ui/react";
 import { Controller, useFormContext } from "react-hook-form";
-import { FormInput } from "../../../../../dex-ui-components";
+import { FormInput } from "@dex-ui-components";
 import { CreateADAOForm } from "../types";
 import { DAOFormContainer } from "./DAOFormContainer";
 

--- a/src/dex-ui/pages/dao/CreateADAO/forms/DAOFormContainer.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/DAOFormContainer.tsx
@@ -1,6 +1,6 @@
 import { Flex } from "@chakra-ui/react";
 import { PropsWithChildren } from "react";
-import { Color } from "../../../../../dex-ui-components";
+import { Color } from "@dex-ui-components";
 
 interface DAOFormContainerProps extends PropsWithChildren {
   rest?: any;

--- a/src/dex-ui/pages/dao/CreateADAO/forms/DAOReviewForm.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/DAOReviewForm.tsx
@@ -10,9 +10,9 @@ import {
   Checkbox,
 } from "@chakra-ui/react";
 import { ReactElement, cloneElement } from "react";
-import { FormInput } from "../../../../../dex-ui-components";
+import { FormInput } from "@dex-ui-components";
 import { DAOFormContainer } from "./DAOFormContainer";
-import { DAOType } from "../../../../services";
+import { DAOType } from "@services";
 
 interface DAOReviewFormProps {
   details: {

--- a/src/dex-ui/pages/dao/CreateADAO/forms/DAOTypeForm.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/DAOTypeForm.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Text, useRadioGroup } from "@chakra-ui/react";
 import { useFormContext } from "react-hook-form";
-import { RadioCard } from "../../../../../dex-ui-components";
+import { RadioCard } from "@dex-ui-components";
 import {
   CreateADAOForm,
   MultiSigDAOGovernanceData,
@@ -10,7 +10,7 @@ import {
 } from "../types";
 import { DAOFormContainer } from "./DAOFormContainer";
 import { useEffect } from "react";
-import { DAOType } from "../../../../services";
+import { DAOType } from "@services";
 
 const newDAOOptions = [
   {

--- a/src/dex-ui/pages/dao/CreateADAO/forms/MultiSigDAOGovernanceForm.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/MultiSigDAOGovernanceForm.tsx
@@ -1,5 +1,5 @@
 import { useFieldArray, useFormContext } from "react-hook-form";
-import { FormInput, FormInputList } from "../../../../../dex-ui-components";
+import { FormInput, FormInputList } from "@dex-ui-components";
 import { CreateAMultiSigDAOForm } from "../types";
 import { DAOFormContainer } from "./DAOFormContainer";
 

--- a/src/dex-ui/pages/dao/CreateADAO/forms/MultiSigDAOReviewForm.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/MultiSigDAOReviewForm.tsx
@@ -1,5 +1,5 @@
 import { useFormContext } from "react-hook-form";
-import { FormInput } from "../../../../../dex-ui-components";
+import { FormInput } from "@dex-ui-components";
 import { CreateAMultiSigDAOForm } from "../types";
 import { DAOReviewForm } from "./DAOReviewForm";
 

--- a/src/dex-ui/pages/dao/CreateADAO/forms/MultiSigDAOVotingForm.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/MultiSigDAOVotingForm.tsx
@@ -1,5 +1,5 @@
 import { useFormContext } from "react-hook-form";
-import { FormInput } from "../../../../../dex-ui-components";
+import { FormInput } from "@dex-ui-components";
 import { CreateAMultiSigDAOForm } from "../types";
 import { DAOFormContainer } from "./DAOFormContainer";
 

--- a/src/dex-ui/pages/dao/CreateADAO/forms/TokenDAOGovernanceForm.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/TokenDAOGovernanceForm.tsx
@@ -2,15 +2,8 @@ import { Text, Flex, Divider, Center, Button } from "@chakra-ui/react";
 import { useFormContext } from "react-hook-form";
 import { CreateATokenDAOForm } from "../types";
 import { DAOFormContainer } from "./DAOFormContainer";
-import {
-  Notification,
-  FormInput,
-  NotficationTypes,
-  useNotification,
-  LoadingDialog,
-  Color,
-} from "../../../../../dex-ui-components";
-import { useCreateToken } from "../../../../hooks";
+import { Notification, FormInput, NotficationTypes, useNotification, LoadingDialog, Color } from "@dex-ui-components";
+import { useCreateToken } from "@hooks";
 import { WarningIcon } from "@chakra-ui/icons";
 
 export function TokenDAOGovernanceForm() {

--- a/src/dex-ui/pages/dao/CreateADAO/forms/TokenDAOReviewForm.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/TokenDAOReviewForm.tsx
@@ -1,5 +1,5 @@
 import { useFormContext } from "react-hook-form";
-import { FormInput } from "../../../../../dex-ui-components";
+import { FormInput } from "@dex-ui-components";
 import { CreateATokenDAOForm } from "../types";
 import { DAOReviewForm } from "./DAOReviewForm";
 

--- a/src/dex-ui/pages/dao/CreateADAO/forms/TokenDAOVotingForm.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/TokenDAOVotingForm.tsx
@@ -1,5 +1,5 @@
 import { SimpleGrid } from "@chakra-ui/react";
-import { FormInput } from "../../../../../dex-ui-components";
+import { FormInput } from "@dex-ui-components";
 import { CreateATokenDAOForm } from "../types";
 import { DAOFormContainer } from "./DAOFormContainer";
 import { useFormContext } from "react-hook-form";

--- a/src/dex-ui/pages/dao/DAODetailsPage/DAODetailsPage.tsx
+++ b/src/dex-ui/pages/dao/DAODetailsPage/DAODetailsPage.tsx
@@ -1,12 +1,12 @@
 import { useNavigate, useParams } from "react-router-dom";
 import { MultiSigDAODashboard } from "./MultiSigDAODashboard";
-import { useDAOs } from "../../../hooks";
-import { LoadingSpinnerLayout, NotFound } from "../../../layouts";
+import { useDAOs } from "@hooks";
+import { LoadingSpinnerLayout, NotFound } from "@layouts";
 import { Text, Flex } from "@chakra-ui/react";
-import { Color } from "../../../../dex-ui-components";
-import { Paths } from "../../../DEX";
+import { Color } from "@dex-ui-components";
+import { Paths } from "@routes";
 import { isNil, isNotNil } from "ramda";
-import { DAOType } from "../../../services";
+import { DAOType } from "@services";
 
 export function DAODetailsPage() {
   const navigate = useNavigate();

--- a/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/AssetsList.tsx
+++ b/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/AssetsList.tsx
@@ -1,7 +1,7 @@
 import { Box, Divider, Flex, SimpleGrid, Text } from "@chakra-ui/react";
-import { Button, Color, HashScanLink, HashscanData, MetricLabel } from "../../../../../dex-ui-components";
+import { Button, Color, HashScanLink, HashscanData, MetricLabel } from "@dex-ui-components";
 import * as R from "ramda";
-import { TokenBalance } from "../../../../hooks";
+import { TokenBalance } from "@hooks";
 interface AssetsListProps {
   assets: TokenBalance[];
   totalAssetValue: number;

--- a/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/DashboardHeader.tsx
+++ b/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/DashboardHeader.tsx
@@ -1,8 +1,8 @@
 import { Text, Flex, HStack, Tag } from "@chakra-ui/react";
 import { Link as ReachLink } from "react-router-dom";
-import { Button, Breadcrumb, ArrowLeftIcon, Color, HashScanLink, HashscanData } from "../../../../../dex-ui-components";
-import { DexService, DAOType } from "../../../../services";
-import { useDexContext } from "../../../../hooks";
+import { Button, Breadcrumb, ArrowLeftIcon, Color, HashScanLink, HashscanData } from "@dex-ui-components";
+import { DexService, DAOType } from "@services";
+import { useDexContext } from "@hooks";
 
 /**
  * TODO: For demo and testing purposes only. Remove this constant once the send transcation flow

--- a/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/DashboardOverview.tsx
+++ b/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/DashboardOverview.tsx
@@ -1,5 +1,5 @@
 import { Flex, Text } from "@chakra-ui/react";
-import { Color, MetricLabel } from "../../../../../dex-ui-components";
+import { Color, MetricLabel } from "@dex-ui-components";
 
 interface DashboardProps {
   totalAssetValue: number;

--- a/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/MembersList.tsx
+++ b/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/MembersList.tsx
@@ -1,5 +1,5 @@
 import { Flex, SimpleGrid, Tag, Text } from "@chakra-ui/react";
-import { Color, HashScanLink, HashscanData } from "../../../../../dex-ui-components";
+import { Color, HashScanLink, HashscanData } from "@dex-ui-components";
 import * as R from "ramda";
 import { Member } from "./MultiSigDAODashboard";
 

--- a/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/MultiSigDAODashboard.tsx
+++ b/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/MultiSigDAODashboard.tsx
@@ -1,13 +1,13 @@
 import { Flex, Tab, TabList, TabPanel, TabPanels, Tabs, Text } from "@chakra-ui/react";
-import { LoadingSpinnerLayout, Page, PageLayout } from "../../../../layouts";
-import { Color } from "../../../../../dex-ui-components";
-import { useAccountTokenBalances, useTabFilters } from "../../../../hooks";
+import { LoadingSpinnerLayout, Page, PageLayout } from "@layouts";
+import { Color } from "@dex-ui-components";
+import { useAccountTokenBalances, useTabFilters } from "@hooks";
 import { TransactionsList } from "./TransactionsList";
 import { MembersList } from "./MembersList";
 import { AssetsList } from "./AssetsList";
 import { DashboardOverview } from "./DashboardOverview";
 import { DashboardHeader } from "./DashboardHeader";
-import { MultiSigDAODetails } from "../../../../services";
+import { MultiSigDAODetails } from "@services";
 
 export interface Member {
   name: string;

--- a/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/TransactionDetails.tsx
+++ b/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/TransactionDetails.tsx
@@ -1,7 +1,7 @@
 import { Text, Flex, AccordionItem, AccordionButton, AccordionIcon, AccordionPanel } from "@chakra-ui/react";
-import { Color } from "../../../../../dex-ui-components";
+import { Color } from "@dex-ui-components";
 import BigNumber from "bignumber.js";
-import { Transaction } from "../../../../hooks";
+import { Transaction } from "@hooks";
 interface TransactionDetailsProps extends Transaction {
   threshold: number;
   index: number;

--- a/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/TransactionsList.tsx
+++ b/src/dex-ui/pages/dao/DAODetailsPage/MultiSigDAODashboard/TransactionsList.tsx
@@ -1,7 +1,7 @@
 import { Text, Accordion } from "@chakra-ui/react";
-import { CardListLayout, LoadingSpinnerLayout, TabFilters } from "../../../../layouts";
+import { CardListLayout, LoadingSpinnerLayout, TabFilters } from "@layouts";
 import { TransactionDetails } from "./TransactionDetails";
-import { TransactionStatus, useDAOTransactions, useTabFilters } from "../../../../hooks";
+import { TransactionStatus, useDAOTransactions, useTabFilters } from "@hooks";
 
 const transactionTabFilters = [[TransactionStatus.Pending], [TransactionStatus.Success, TransactionStatus.Failed]];
 const defaultTransactionFilters = [TransactionStatus.Pending, TransactionStatus.Success, TransactionStatus.Failed];

--- a/src/dex-ui/pages/dao/DAOsListPage/DAOCard.tsx
+++ b/src/dex-ui/pages/dao/DAOsListPage/DAOCard.tsx
@@ -1,9 +1,9 @@
 import { Text, Grid, GridItem, Flex, Card } from "@chakra-ui/react";
 import { ReactNode } from "react";
-import { Color } from "../../../../dex-ui-components";
+import { Color } from "@dex-ui-components";
 import { useNavigate } from "react-router-dom";
-import { Paths } from "../../../DEX";
-import { DAOType } from "../../../services";
+import { Paths } from "@routes";
+import { DAOType } from "@services";
 
 export interface DAOCardProps {
   key: React.Key | null | undefined;

--- a/src/dex-ui/pages/dao/DAOsListPage/DAOsListPage.tsx
+++ b/src/dex-ui/pages/dao/DAOsListPage/DAOsListPage.tsx
@@ -1,12 +1,12 @@
 import { Text, Box, Center } from "@chakra-ui/react";
-import { CardGridLayout, Page, PageHeader } from "../../../layouts";
-import { Notification, useNotification, NotficationTypes } from "../../../../dex-ui-components";
-import { useDAOs } from "../../../hooks";
+import { CardGridLayout, Page, PageHeader } from "@layouts";
+import { Notification, useNotification, NotficationTypes } from "@dex-ui-components";
+import { useDAOs } from "@hooks";
 import { useLocation, useNavigate } from "react-router-dom";
-import { PrimaryHeaderButton } from "../../../components";
+import { PrimaryHeaderButton } from "@components";
 import { DAOCard } from "./DAOCard";
-import { Paths } from "../../../DEX";
-import { DAO } from "../../../services";
+import { Paths } from "@routes";
+import { DAO } from "@services";
 
 export function DAOsListPage() {
   const daos = useDAOs();

--- a/src/dex-ui/routes/index.ts
+++ b/src/dex-ui/routes/index.ts
@@ -1,0 +1,1 @@
+export * from "./routes";

--- a/src/dex-ui/routes/routes.ts
+++ b/src/dex-ui/routes/routes.ts
@@ -1,0 +1,26 @@
+export const Paths = {
+  Home: "/",
+  Swap: {
+    default: "/swap",
+  },
+  Pools: {
+    default: "/pools",
+    AddLiquidity: "/pools/add-liquidity",
+    Withdraw: "/pools/withdraw",
+    CreatePool: "/pools/create-pool",
+  },
+  Governance: {
+    default: "/governance",
+    ProposalDetails: "/governance/proposal-details",
+    SelectProposalType: "/governance/select-proposal-type",
+    CreateNewToken: "/governance/select-proposal-type/new-token",
+    CreateText: "/governance/select-proposal-type/text",
+    CreateTokenTransfer: "/governance/select-proposal-type/token-transfer",
+    CreateContractUpgrade: "/governance/select-proposal-type/contract-upgrade",
+  },
+  DAOs: {
+    default: "/daos",
+    CreateDAO: "/daos/create",
+    DAODetails: "/dao",
+  },
+};

--- a/src/dex-ui/theme/theme.ts
+++ b/src/dex-ui/theme/theme.ts
@@ -1,20 +1,32 @@
 import { extendTheme } from "@chakra-ui/react";
 import {
+  Color,
   TextStyles,
   ButtonStyles,
   NumberInputStyles,
   InputStyles,
   CardStyles,
-  TabsStyles,
-} from "../../dex-ui-components/base";
+  SelectStyles,
+  TooltipStyles,
+  StepsV2Theme,
+} from "@dex-ui-components";
 
 export const DEXTheme = extendTheme({
+  styles: {
+    global: {
+      body: {
+        background: Color.Primary_Bg,
+      },
+    },
+  },
   textStyles: TextStyles,
   components: {
     Button: ButtonStyles,
     NumberInput: NumberInputStyles,
     Input: InputStyles,
     Card: CardStyles,
-    Tabs: TabsStyles,
+    Select: SelectStyles,
+    Tooltip: TooltipStyles,
+    Steps: StepsV2Theme,
   },
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "target": "ES2017",
     "lib": [
@@ -22,5 +23,5 @@
   },
   "include": [
     "src",
-  ]
+  ],
 }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,79 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "@dex-ui": [
+        "dex-ui"
+      ],
+      "@dex-ui/*": [
+        "dex-ui/*"
+      ],
+      "@components": [
+        "dex-ui/components"
+      ],
+      "@components/*": [
+        "dex-ui/components/*"
+      ],
+      "@context": [
+        "dex-ui/context"
+      ],
+      "@context/*": [
+        "dex-ui/context/*"
+      ],
+      "@hooks": [
+        "dex-ui/hooks"
+      ],
+      "@hooks/*": [
+        "dex-ui/hooks/*"
+      ],
+      "@layouts": [
+        "dex-ui/layouts"
+      ],
+      "@layouts/*": [
+        "dex-ui/layouts/*"
+      ],
+      "@pages": [
+        "dex-ui/pages"
+      ],
+      "@pages/*": [
+        "dex-ui/pages/*"
+      ],
+      "@services": [
+        "dex-ui/services"
+      ],
+      "@services/*": [
+        "dex-ui/services/*"
+      ],
+      "@store": [
+        "dex-ui/store"
+      ],
+      "@store/*": [
+        "dex-ui/store/*"
+      ],
+      "@theme": [
+        "dex-ui/theme"
+      ],
+      "@theme/*": [
+        "dex-ui/theme/*"
+      ],
+      "@routes": [
+        "dex-ui/routes"
+      ],
+      "@routes/*": [
+        "dex-ui/routes/*"
+      ],
+      "@utils": [
+        "dex-ui/utils"
+      ],
+      "@utils/*": [
+        "dex-ui/utils/*"
+      ],
+      "@dex-ui-components": [
+        "dex-ui-components"
+      ],
+      "@dex-ui-components/*": [
+        "dex-ui-components/*"
+      ],
+    },
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,7 +58,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.8.0":
+"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.6.0", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.8.0":
   version "7.21.4"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.21.4.tgz#c6dc73242507b8e2a27fd13a9c1814f9fa34a659"
   integrity sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==
@@ -2003,6 +2003,15 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
+"@craco/craco@^5.5.0":
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/@craco/craco/-/craco-5.9.0.tgz#dcd34330b558596a4841374743071b7fa041dce9"
+  integrity sha512-2Q8gIB4W0/nPiUxr9iAKUhGsFlXYN0/wngUdK1VWtfV2NtBv+yllNn2AjieaLbttgpQinuOYmDU65vocC0NMDg==
+  dependencies:
+    cross-spawn "^7.0.0"
+    lodash "^4.17.15"
+    webpack-merge "^4.2.2"
 
 "@csstools/normalize.css@*":
   version "12.0.0"
@@ -4644,7 +4653,7 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.1.tgz#3286741fb8f1e1580ac28784add4c7a1d49bdfbc"
   integrity sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==
 
-"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14", "@types/babel__core@^7.1.7":
+"@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14", "@types/babel__core@^7.1.3", "@types/babel__core@^7.1.7":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.0.tgz#61bc5a4cae505ce98e1e36c5445e4bee060d8891"
   integrity sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==
@@ -5193,7 +5202,7 @@
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
-"@types/webpack@^4.41.26", "@types/webpack@^4.41.8":
+"@types/webpack@^4.39.2", "@types/webpack@^4.41.26", "@types/webpack@^4.41.8":
   version "4.41.33"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.33.tgz#16164845a5be6a306bcbe554a8e67f9cac215ffc"
   integrity sha512-PPajH64Ft2vWevkerISMtnZ8rTs4YmRbs+23c402J0INmxDKCrhZNvwZYtzx96gY2wAtXdrK1BS2fiC8MlLr3g==
@@ -7629,6 +7638,17 @@ cpy@^8.1.2:
     p-all "^2.1.0"
     p-filter "^2.1.0"
     p-map "^3.0.0"
+
+craco@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/craco/-/craco-0.0.3.tgz#1e464b0ae5d9176570382d3a3fcdbf3599577012"
+  integrity sha512-eeibbwJm1CTf/j3xvNgNmsRS7abegp4Cfm5qtn5nE9/0JjZRas+FHj8IlT8FMFWR0XOyZFGcWZgzaTU19DNGoQ==
+  dependencies:
+    "@babel/core" "^7.6.0"
+    "@craco/craco" "^5.5.0"
+    "@types/babel__core" "^7.1.3"
+    "@types/webpack" "^4.39.2"
+    webpack "^4.41.0"
 
 crc-32@^1.2.0:
   version "1.2.2"
@@ -18586,6 +18606,13 @@ webpack-manifest-plugin@^4.0.2:
     tapable "^2.0.0"
     webpack-sources "^2.2.0"
 
+webpack-merge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
+  integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
+  dependencies:
+    lodash "^4.17.15"
+
 webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
@@ -18619,7 +18646,7 @@ webpack-virtual-modules@^0.4.1:
   resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.4.6.tgz#3e4008230731f1db078d9cb6f68baf8571182b45"
   integrity sha512-5tyDlKLqPfMqjT3Q9TAqf2YqjwmnUleZwzJi1A5qXnlBCdj2AtOJ6wAWdglTIDOPgOiOrXeBeFcsQ8+aGQ6QbA==
 
-webpack@4:
+webpack@4, webpack@^4.41.0:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==


### PR DESCRIPTION
**Description**:

Primary UI domain folders can now be directly accessed using designated aliases:

```typescript     
    "@dex-ui": path.resolve(__dirname, "src/dex-ui"),
    "@components": path.resolve(__dirname, "src/dex-ui/components"),
    "@context": path.resolve(__dirname, "src/dex-ui/context"),
    "@hooks": path.resolve(__dirname, "src/dex-ui/hooks"),
    "@layouts": path.resolve(__dirname, "src/dex-ui/layouts"),
    "@pages": path.resolve(__dirname, "src/dex-ui/pages"),
    "@services": path.resolve(__dirname, "src/dex-ui/services"),
    "@store": path.resolve(__dirname, "src/dex-ui/store"),
    "@theme": path.resolve(__dirname, "src/dex-ui/theme"),
    "@routes": path.resolve(__dirname, "src/dex-ui/routes"),
    "@utils": path.resolve(__dirname, "src/dex-ui/utils"),
    "@dex-ui-components": path.resolve(__dirname, "src/dex-ui-components"),
```

**Example**

Before: `import { HashscanLink } from "../../../../../../../dex-ui-components"`
After: `import { HashscanLink } from "@dex-ui-components"`

Notes:
- Applied path aliases to DAO UI components