### PR TITLE
fix: Made DAO logo field optional

### DIFF
--- a/src/dex-ui/pages/dao/CreateADAO/CreateADAOPage.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/CreateADAOPage.tsx
@@ -140,12 +140,12 @@ export function CreateADAOPage() {
   async function onSubmit(data: CreateADAOForm) {
     if (data.type === DAOType.GovernanceToken) {
       const tokenDAOData = data as CreateATokenDAOForm;
-      const { governance, voting } = tokenDAOData;
+      const { governance, voting, type, name, logoUrl = "", isPublic } = tokenDAOData;
       return createDAO.mutate({
-        type: tokenDAOData.type,
-        name: tokenDAOData.name,
-        logoUrl: tokenDAOData.logoUrl ?? "",
-        isPrivate: !tokenDAOData.isPublic,
+        type,
+        name,
+        logoUrl,
+        isPrivate: !isPublic,
         tokenId: governance.token.id,
         treasuryWalletAccountId: governance.token.treasuryWalletAccountId,
         quorum: voting.quorum,

--- a/src/dex-ui/pages/dao/CreateADAO/forms/DAODetailsForm.tsx
+++ b/src/dex-ui/pages/dao/CreateADAO/forms/DAODetailsForm.tsx
@@ -51,7 +51,7 @@ export function DAODetailsForm() {
           type: "text",
           placeholder: "Enter image URL",
           register: {
-            ...register("logoUrl", { required: { value: true, message: "A logo url is required." } }),
+            ...register("logoUrl"),
           },
         }}
         isInvalid={Boolean(errors.logoUrl)}


### PR DESCRIPTION
🛠️ Fixes
- The Logo URL field in the Create DAO Wizard is no longer required to create a DAO

📝 Tech Notes
- The DAO Smart Contracts currently require a Logo URL with a length greater than 1. This bugfix requires changes on smart contracts to work end-to-end. Smart Contract PR: https://github.com/hashgraph/hedera-accelerator-defi-dex/pull/445
