### PR TITLE
feat: Removed Duplicate react-router Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-paginate": "^8.1.4",
     "react-query": "^3.39.2",
     "react-quill": "^2.0.0",
-    "react-router": "^6.11.1",
     "react-router-dom": "^6.11.1",
     "react-scripts": "5.0.1",
     "use-immer": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15503,7 +15503,7 @@ react-router-dom@^6.11.1:
     "@remix-run/router" "1.6.1"
     react-router "6.11.1"
 
-react-router@6.11.1, react-router@^6.11.1:
+react-router@6.11.1:
   version "6.11.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.11.1.tgz#6e58458c03e16834dda2b433c6adb9e7c2b1d7a8"
   integrity sha512-OZINSdjJ2WgvAi7hgNLazrEV8SGn6xrKA+MkJe9wVDMZ3zQ6fdJocUjpCUCI0cNrelWjcvon0S/QK/j0NzL3KA==


### PR DESCRIPTION
**Tech Notes**
- Removed `react-router` as a dependency. `react-router-dom` contains all of the features from `react-router`.