### PR TITLE
feat: [US34213] Prevent Duplicate Owner Confirmations

### DIFF
--- a/src/dex-ui-components/base/Icons/CheckCircleUnfilledIcon.tsx
+++ b/src/dex-ui-components/base/Icons/CheckCircleUnfilledIcon.tsx
@@ -1,0 +1,19 @@
+import { createIcon } from "@chakra-ui/react";
+import { Color } from "../../themes";
+
+export const CheckCircleUnfilledIcon = createIcon({
+  displayName: "CheckCircleUnfilledIcon",
+  viewBox: "0 0 16 16",
+  path: (
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="1.67"
+      d="m5.667 8 1.555 1.556 3.111-3.112M15 8A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"
+    />
+  ),
+  defaultProps: {
+    fill: "none",
+    stroke: Color.Neutral._500,
+  },
+});

--- a/src/dex-ui-components/base/Icons/index.ts
+++ b/src/dex-ui-components/base/Icons/index.ts
@@ -22,3 +22,4 @@ export * from "./CogIcon";
 export * from "./CheckCircleIcon";
 export * from "./XIcon";
 export * from "./ClockIcon";
+export * from "./CheckCircleUnfilledIcon";

--- a/src/dex-ui/pages/ProposalDetails/ProposalDetailsControls.tsx
+++ b/src/dex-ui/pages/ProposalDetails/ProposalDetailsControls.tsx
@@ -44,7 +44,7 @@ export function ProposalDetailsControls(props: ProposalDetailsControlsProps) {
 
   let isUserProposalCreator = false;
   try {
-    isUserProposalCreator = formattedProposal?.author === wallet.getSigner().getAccountId().toString();
+    isUserProposalCreator = formattedProposal?.author === wallet.savedPairingData?.accountIds[0] ?? "";
   } catch (error) {
     console.log(error);
   }

--- a/src/dex-ui/pages/dao/MultiSigTransactionModal/MultiSigTransactionReviewForm.tsx
+++ b/src/dex-ui/pages/dao/MultiSigTransactionModal/MultiSigTransactionReviewForm.tsx
@@ -14,7 +14,7 @@ interface MultiSigTransactionReviewFormProps {
 export function MultiSigTransactionReviewForm(props: MultiSigTransactionReviewFormProps) {
   const { safeAccountId } = props;
   const { wallet } = useDexContext(({ wallet }) => ({ wallet }));
-  const walletAccountId = wallet.getSigner().getAccountId().toString();
+  const walletAccountId = wallet.savedPairingData?.accountIds[0] ?? "";
   const { setValue, getValues } = useFormContext<CreateMultiSigTransactionForm>();
   const formValues = getValues();
   const { tokenId, amount, recipientAccountId } = formValues;

--- a/src/dex-ui/pages/dao/TokenTransactionDetails/TokenTransactionDetails.tsx
+++ b/src/dex-ui/pages/dao/TokenTransactionDetails/TokenTransactionDetails.tsx
@@ -31,7 +31,7 @@ import { TransactionStatusAsTagVariant } from "../constants";
 export function TokenTransactionDetails() {
   const { accountId: daoAccountId = "", transactionHash = "" } = useParams();
   const { wallet } = useDexContext(({ wallet }) => ({ wallet }));
-  const connectedWalletId = wallet.getSigner().getAccountId().toString();
+  const connectedWalletId = wallet.savedPairingData?.accountIds[0] ?? "";
   const daosQueryResults = useDAOs<MultiSigDAODetails>(daoAccountId);
   const { data: daos } = daosQueryResults;
   const dao = daos?.find((dao: MultiSigDAODetails) => dao.accountId === daoAccountId);


### PR DESCRIPTION
**Context**

The Safe contract allows a single owner to approve transactions multiple times. The confirmation count in the contract state is only incremented once but an `ApproveHash` event is emitted every time the owner sends an approval transaction. This causes the UI to show duplicate confirmations.

**Features**
- The disabled "Confirmed by you" button is displayed if the currently connected wallet has already confirmed the Token Transfer transaction.
- Confirmation counts no longer incorporate duplicate confirmations.

**Tech Notes**
- Logic to gather `approvals` account ID list and `approvalCount` has been updated to filter out duplicate ApproveHash events.

**Screenshots**
<img width="336" alt="Screen Shot 2023-05-11 at 12 23 15 PM" src="https://github.com/hashgraph/hedera-accelerator-defi-dex-ui/assets/54907098/4e3df6cf-ad6f-4a75-aa46-19bffdc27e25">