### PR TITLE
feat/US34227 - Set Token Allowance for Token Transfer Proposal before Execution as a part of v36 security changes

### DIFF
--- a/src/dex-ui/hooks/governance/useExecuteProposal.tsx
+++ b/src/dex-ui/hooks/governance/useExecuteProposal.tsx
@@ -9,6 +9,9 @@ interface UseExecuteProposalParams {
   contractId: string;
   title: string;
   signer: HashConnectSigner;
+  transfersFromAccount?: string;
+  tokenId?: string;
+  tokenAmount?: number;
 }
 
 export function useExecuteProposal(id: string | undefined) {
@@ -21,8 +24,7 @@ export function useExecuteProposal(id: string | undefined) {
   >(
     async (params: UseExecuteProposalParams) => {
       if (isNil(id)) return;
-      const { contractId, title, signer } = params;
-      return DexService.executeProposal({ contractId, title, signer });
+      return DexService.executeProposal({ ...params });
     },
     {
       onSuccess: () => {

--- a/src/dex-ui/pages/CreateProposal/ProposalForms/TokenTransferProposalForm.tsx
+++ b/src/dex-ui/pages/CreateProposal/ProposalForms/TokenTransferProposalForm.tsx
@@ -166,7 +166,7 @@ export function TokenTransferProposalForm(): ReactElement {
                         {...register("amountToTransfer", {
                           valueAsNumber: true,
                           required: { value: true, message: "A token amount is required." },
-                          min: { value: 0, message: "A token amount must be greater than 0." },
+                          validate: (value) => value > 0 || "A token amount must be greater than 0.",
                         })}
                       />
                       <FormErrorMessage>{errors.amountToTransfer && errors.amountToTransfer.message}</FormErrorMessage>

--- a/src/dex-ui/pages/ProposalDetails/ProposalDetailsControls.tsx
+++ b/src/dex-ui/pages/ProposalDetails/ProposalDetailsControls.tsx
@@ -53,7 +53,14 @@ export function ProposalDetailsControls(props: ProposalDetailsControlsProps) {
   async function handleExecuteClicked() {
     props.resetServerState();
     const signer = wallet.getSigner();
-    executeProposal.mutate({ contractId: proposal.data?.contractId ?? "", title: proposal.data?.title ?? "", signer });
+    executeProposal.mutate({
+      contractId: proposal.data?.contractId ?? "",
+      title: proposal.data?.title ?? "",
+      signer,
+      transfersFromAccount: proposal.data?.transferFromAccount,
+      tokenId: proposal.data?.tokenToTransfer,
+      tokenAmount: proposal.data?.transferTokenAmount,
+    });
   }
 
   function handleCancelProposalClicked() {

--- a/src/dex-ui/services/HederaService/GovernorService.ts
+++ b/src/dex-ui/services/HederaService/GovernorService.ts
@@ -210,6 +210,10 @@ interface ExecuteProposalParams {
   contractId: string;
   title: string;
   signer: HashConnectSigner;
+  transfersFromAccount?: string;
+  transfersToAccount?: string;
+  tokenId?: string;
+  tokenAmount?: number;
 }
 
 /**
@@ -218,10 +222,20 @@ interface ExecuteProposalParams {
  * @returns
  */
 const executeProposal = async (params: ExecuteProposalParams) => {
-  const { contractId, title, signer } = params;
+  const { contractId, title, signer, transfersFromAccount, tokenId, tokenAmount } = params;
   const governorContractId = ContractId.fromString(contractId);
   /** This parameter is named 'description' on the contract function */
   const contractFunctionParameters = new ContractFunctionParameters().addString(title);
+
+  if (tokenId && transfersFromAccount && tokenAmount) {
+    await DexService.setTokenAllowance({
+      tokenId,
+      walletId: transfersFromAccount,
+      spenderContractId: contractId,
+      tokenAmount,
+      signer: signer,
+    });
+  }
   const executeProposalTransaction = await new ContractExecuteTransaction()
     .setContractId(governorContractId)
     .setFunction(GovernorContractFunctions.ExecuteProposal, contractFunctionParameters)

--- a/src/dex-ui/services/JsonRpcService/Governor.ts
+++ b/src/dex-ui/services/JsonRpcService/Governor.ts
@@ -59,6 +59,10 @@ type ProposalDetailsResponse = {
   title: string;
   description: string;
   link: string;
+  transferFromAccount?: string | undefined;
+  transferToAccount?: string | undefined;
+  tokenToTransfer?: string | undefined;
+  transferTokenAmount?: number | undefined;
 };
 
 async function fetchProposalDetails(governorAccountId: string, proposalId: string): Promise<ProposalDetailsResponse> {

--- a/src/dex-ui/services/MirrorNodeService/types.ts
+++ b/src/dex-ui/services/MirrorNodeService/types.ts
@@ -122,6 +122,7 @@ interface MirrorNodeDecodedProposalEvent {
   title?: string;
   link?: string;
   timestamp?: string;
+  data?: string;
 }
 
 interface MirrorNodeEventLog {

--- a/src/dex-ui/services/abi/GovernorCountingSimpleInternal.json
+++ b/src/dex-ui/services/abi/GovernorCountingSimpleInternal.json
@@ -9,6 +9,17 @@
       "type": "error"
     },
     {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "message",
+          "type": "string"
+        }
+      ],
+      "name": "InvalidInput",
+      "type": "error"
+    },
+    {
       "anonymous": false,
       "inputs": [
         {
@@ -139,6 +150,12 @@
           "internalType": "uint256",
           "name": "endBlock",
           "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
         }
       ],
       "name": "ProposalDetails",
@@ -405,6 +422,35 @@
         }
       ],
       "name": "castVoteBySig",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "proposalId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint8",
+          "name": "support",
+          "type": "uint8"
+        }
+      ],
+      "name": "castVotePublic",
       "outputs": [
         {
           "internalType": "uint256",
@@ -796,8 +842,8 @@
           "type": "address"
         },
         {
-          "internalType": "contract IGODHolder",
-          "name": "_godHolder",
+          "internalType": "contract ITokenHolder",
+          "name": "_tokenHolder",
           "type": "address"
         },
         {

--- a/src/dex-ui/services/contractsUAT.json
+++ b/src/dex-ui/services/contractsUAT.json
@@ -37,12 +37,12 @@
   },
   {
     "name": "governortransfertoken",
-    "id": "0.0.3778809",
-    "address": "0x000000000000000000000000000000000039a8f9",
-    "timestamp": "2023-03-14T13:28:56.304Z",
-    "hash": "42b45fcd1c959ce3c6adbd40e6ffdc77",
-    "transparentProxyAddress": "0x000000000000000000000000000000000039a901",
-    "transparentProxyId": "0.0.3778817"
+    "id": "0.0.4643262",
+    "address": "0x000000000000000000000000000000000046d9be",
+    "timestamp": "2023-05-12T10:36:36.488Z",
+    "hash": "f4c1c05cca407a07e2090149d2c1235f",
+    "transparentProxyAddress": "0x000000000000000000000000000000000046d9c5",
+    "transparentProxyId": "0.0.4643269"
   },
   {
     "name": "governorupgrade",
@@ -55,12 +55,12 @@
   },
   {
     "name": "governortextproposal",
-    "id": "0.0.4374067",
-    "address": "0x000000000000000000000000000000000042be33",
-    "timestamp": "2023-04-24T08:04:23.156Z",
-    "hash": "3f9f6825682dde0f0fc81dbc716eb286",
-    "transparentProxyAddress": "0x000000000000000000000000000000000042be3c",
-    "transparentProxyId": "0.0.4374076"
+    "id": "0.0.4643260",
+    "address": "0x000000000000000000000000000000000046d9bc",
+    "timestamp": "2023-05-12T10:36:34.798Z",
+    "hash": "00578564141bf640446d4bba5624dcd0",
+    "transparentProxyAddress": "0x000000000000000000000000000000000046d9c4",
+    "transparentProxyId": "0.0.4643268"
   },
   {
     "name": "governortokencreate",

--- a/src/dex-ui/store/governanceSlice/type.ts
+++ b/src/dex-ui/store/governanceSlice/type.ts
@@ -64,6 +64,10 @@ interface Proposal {
   timeRemaining: BigNumber | undefined;
   state: ProposalState | undefined;
   timestamp: string | undefined;
+  transferFromAccount?: string | undefined;
+  transferToAccount?: string | undefined;
+  tokenToTransfer?: string | undefined;
+  transferTokenAmount?: number | undefined;
   votes: {
     yes: BigNumber | undefined;
     no: BigNumber | undefined;


### PR DESCRIPTION
**Description**:
1. This PR sets up token Allowance for Token Transfer before executing.
2. The `tokenTransferDetails` are only fetched when fetching the proposal details in "Proposal Details" page on the list page the details are not required as of now.

**Related issue(s)**:
1. I was able to test only once with proposal due to the issue with testnet (I will run some more test on the same)