### PR TITLE
Feat/US-34355: Send button on Asset cards the opens token transfer proposal with auto populated  fields

### DIFF
--- a/src/dex-ui/pages/dao/MultiSigDAODashboard/AssetsList.tsx
+++ b/src/dex-ui/pages/dao/MultiSigDAODashboard/AssetsList.tsx
@@ -1,9 +1,10 @@
-import { Box, Divider, Flex, SimpleGrid, Text } from "@chakra-ui/react";
+import { Box, Button, Divider, Flex, SimpleGrid, Text } from "@chakra-ui/react";
 import { Color, HashScanLink, HashscanData, MetricLabel } from "@dex-ui-components";
 import * as R from "ramda";
-import { useOutletContext } from "react-router-dom";
+import { useNavigate, useOutletContext } from "react-router-dom";
 import { MultiSigDAODetailsContext } from "./types";
 import { HBARTokenSymbol } from "@services";
+import { Paths } from "@dex-ui/routes";
 
 export function AssetsList() {
   const { tokenBalances: assets } = useOutletContext<MultiSigDAODetailsContext>();
@@ -11,6 +12,7 @@ export function AssetsList() {
   const hbarIndex = assets?.findIndex((asset) => asset.name === HBARTokenSymbol);
   // @ts-ignore - @types/ramda has not yet been updated with a type for R.swap
   const assetsWithHBARFirst: Asset[] = R.swap(0, hbarIndex, assets);
+  const navigate = useNavigate();
 
   return (
     <>
@@ -34,7 +36,24 @@ export function AssetsList() {
               >
                 <Flex direction="row" justifyContent="space-between" gap="2">
                   <Text textStyle="p medium semibold">{name}</Text>
-                  <HashScanLink id={tokenId} type={HashscanData.Token} />
+                  {tokenId && (
+                    <Flex gap="2">
+                      <HashScanLink id={tokenId} type={HashscanData.Token} />
+                      <Button
+                        variant="primary"
+                        isDisabled={!balance}
+                        onClick={() => {
+                          navigate(`../${Paths.DAOs.CreateDAOProposal}/${Paths.DAOs.DAOTokenTransferDetails}`, {
+                            state: {
+                              tokenId: tokenId,
+                            },
+                          });
+                        }}
+                      >
+                        Send
+                      </Button>
+                    </Flex>
+                  )}
                 </Flex>
                 <Divider />
                 <Flex direction="row" justifyContent="space-between">


### PR DESCRIPTION
**Description**:
Implemented Send token for MultiSig Assets
- navigate from assets to token transfer form
- auto populate fields based on asset.
- added dropdown for tokens to select.

<img width="1536" alt="Screenshot 2023-07-24 at 4 51 35 PM" src="https://github.com/hashgraph/hedera-accelerator-defi-dex-ui/assets/132666177/69191ec8-4db1-4781-bffb-80ec8dbfe79f">
<img width="776" alt="Screenshot 2023-07-24 at 4 51 53 PM" src="https://github.com/hashgraph/hedera-accelerator-defi-dex-ui/assets/132666177/6fbe7300-7986-4470-a9e1-58604aa3d9dd">

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
