### PR TITLE
feat: Pattern input constraints for Token Input component

### DIFF
--- a/src/dex-ui-components/base/Form/index.ts
+++ b/src/dex-ui-components/base/Form/index.ts
@@ -1,3 +1,4 @@
 export * from "./FormDropdown";
 export * from "./FormTokenInput";
 export * from "./useHalfMaxButtons";
+export * from "./useFormTokenInputPattern";

--- a/src/dex-ui-components/base/Form/useFormTokenInputPattern.tsx
+++ b/src/dex-ui-components/base/Form/useFormTokenInputPattern.tsx
@@ -1,0 +1,45 @@
+import { ChangeEvent, useState } from "react";
+
+/**
+ * Regex pattern used to restrict the values a user can enter in a token input component.
+ *
+ * @remarks
+ * - The regex `/^(0|[1-9]\d*)?(\.\d*)?$/` matches a floating-point number in the string.
+ * - The first part of the regex, `^(0|[1-9]\d*)?`, matches an optional leading zero or a sequence of one or more
+ * digits.
+ * - The second part of the regex, `(\.\d*)?`, matches an optional decimal point followed by zero or more digits.
+ * @example
+ * For example, the following strings would all match the regex:
+ * ```
+ * "0"
+ * "1.23"
+ * "0.123"
+ * "123"
+ * "."
+ * ```
+ * @example
+ * The following strings would not match the regex:
+ * ```
+ * "abc"
+ * "123.a"
+ * "-1.23"
+ * ```
+ */
+const TokenInputPattern = /^(0|[1-9]\d*)?(\.\d*)?$/;
+
+export function useFormTokenInputPattern(valueSetter: (value: string) => void) {
+  const [previousValue, setPreviousValue] = useState("");
+
+  function handleTokenInputChangeWithPattern(event: ChangeEvent<HTMLSelectElement>) {
+    if (!TokenInputPattern.test(event.target.value)) {
+      return valueSetter(previousValue);
+    }
+    setPreviousValue(event.target.value);
+    valueSetter(event.target.value);
+  }
+
+  return {
+    previousValue,
+    handleTokenInputChangeWithPattern,
+  };
+}

--- a/src/dex-ui-components/base/Form/useHalfMaxButtons.tsx
+++ b/src/dex-ui-components/base/Form/useHalfMaxButtons.tsx
@@ -1,13 +1,13 @@
 import { formulaTypes } from "@dex-ui-components/presets/types";
-import { halfOf } from "@dex-ui-components/presets/utils";
-import { useState } from "react";
+import BigNumber from "bignumber.js";
 
-export function useHalfMaxButtons(initialAmount: number, amountSetter?: (amount: number) => void) {
-  const [amount, setAmount] = useState(initialAmount);
-
+export function useHalfMaxButtons(maxBalance: string, amountSetter: (amount: string | undefined) => void) {
   function setInputAmountWithFormula(formula: formulaTypes = formulaTypes.MAX) {
-    const newAmount = formula === formulaTypes.MAX ? initialAmount : halfOf(Number(initialAmount));
-    amountSetter ? amountSetter(newAmount) : setAmount(newAmount);
+    if (BigNumber(maxBalance).isNaN()) {
+      return amountSetter(undefined);
+    }
+    const newAmount = formula === formulaTypes.MAX ? maxBalance : BigNumber(maxBalance).div(2).toString();
+    amountSetter(newAmount);
   }
 
   function handleMaxButtonClicked() {
@@ -18,7 +18,6 @@ export function useHalfMaxButtons(initialAmount: number, amountSetter?: (amount:
     setInputAmountWithFormula(formulaTypes.HALF);
   }
   return {
-    amount,
     handleMaxButtonClicked,
     handleHalfButtonClicked,
   };

--- a/src/dex-ui/pages/dao/DAOProposals/types.ts
+++ b/src/dex-ui/pages/dao/DAOProposals/types.ts
@@ -27,7 +27,7 @@ export interface CreateDAOTokenTransferForm extends CreateDAOProposalFormBase {
   recipientAccountId: string;
   linkToDiscussion: string;
   tokenId: string;
-  amount: number;
+  amount: string | undefined;
   decimals: number;
 }
 


### PR DESCRIPTION
**Description**
- Created a `useFormTokenInputPattern` hook that can be used to apply a regex guard to input components (intended to be used with Token Input components).
- Changing the assets dropdown no longer sets the value in the amount input.

**Pattern Details**
```
/**
 * Regex pattern used to restrict the values a user can enter in a token input component.
 *
 * @remarks
 * - The regex `/^(0|[1-9]\d*)?(\.\d*)?$/` matches a floating-point number in the string.
 * - The first part of the regex, `^(0|[1-9]\d*)?`, matches an optional leading zero or a sequence of one or more
 * digits.
 * - The second part of the regex, `(\.\d*)?`, matches an optional decimal point followed by zero or more digits.
 * @example
 * For example, the following strings would all match the regex:
 * ```
 * "0"
 * "1.23"
 * "0.123"
 * "123"
 * "."
 * ```
 * @example
 * The following strings would not match the regex:
 * ```
 * "abc"
 * "123.a"
 * "-1.23"
 * ```
 */
```

**Screenshots**
![Screen Shot 2023-07-28 at 10 51 35 AM](https://github.com/hashgraph/hedera-accelerator-defi-dex-ui/assets/54907098/a891aa48-529e-4064-b8f3-82c0d5840235)
![Screen Shot 2023-07-28 at 10 51 56 AM](https://github.com/hashgraph/hedera-accelerator-defi-dex-ui/assets/54907098/e9d2598c-5ce0-40c1-8822-3a388b13baa3)
![Screen Shot 2023-07-28 at 10 52 13 AM](https://github.com/hashgraph/hedera-accelerator-defi-dex-ui/assets/54907098/9f1d74f1-03ca-4998-a15e-5f3a7c5bfbe8)