### PR TITLE
Fix-US34370-TA99546: HBAR Association to wallet in Swap, Fix Cancel Button Not visible for Governance

### DIFF
--- a/src/dex-ui/pages/CreateProposal/ProposalForms/ContractUpgradeProposalForm.tsx
+++ b/src/dex-ui/pages/CreateProposal/ProposalForms/ContractUpgradeProposalForm.tsx
@@ -98,7 +98,9 @@ export function ContractUpgradeProposalForm(): ReactElement {
                       control={control}
                       rules={{
                         required: { value: true, message: "Description is required." },
-                        minLength: { value: 107, message: "Please enter atleast 100 characters in the description." },
+                        validate: (value) =>
+                          (value.length > 0 && value.length <= 240) ||
+                          "Maximum character count for the description is 240.",
                       }}
                       render={({ field }) => (
                         <TextEditor

--- a/src/dex-ui/pages/CreateProposal/ProposalForms/TextProposalForm.tsx
+++ b/src/dex-ui/pages/CreateProposal/ProposalForms/TextProposalForm.tsx
@@ -9,7 +9,7 @@ import { Paths } from "@routes";
 import { useCreateTextProposal } from "@hooks";
 import { TransactionResponse } from "@hashgraph/sdk";
 import { WarningIcon } from "@chakra-ui/icons";
-import { DEFAULT_NFT_TOKEN_SERIAL_ID } from "@services";
+import { DEFAULT_NFT_TOKEN_SERIAL_ID, EDITOR_DEFAULT_CHARACTER_COUNT } from "@services";
 
 export function TextProposalForm() {
   const navigate = useNavigate();
@@ -95,7 +95,9 @@ export function TextProposalForm() {
                       control={control}
                       rules={{
                         required: { value: true, message: "Description is required." },
-                        minLength: { value: 107, message: "Please enter at least 100 characters in the description." },
+                        validate: (value) =>
+                          (value.length > 0 && value.length <= 240 + EDITOR_DEFAULT_CHARACTER_COUNT) ||
+                          "Maximum character count for the description is 240.",
                       }}
                       render={({ field }) => (
                         <TextEditor

--- a/src/dex-ui/pages/CreateProposal/ProposalForms/TokenTransferProposalForm.tsx
+++ b/src/dex-ui/pages/CreateProposal/ProposalForms/TokenTransferProposalForm.tsx
@@ -10,7 +10,7 @@ import { Paths } from "@routes";
 import { TransactionResponse } from "@hashgraph/sdk";
 import { CreateProposalLocationProps, TokenTransferProposalFormData } from "./types";
 import { WarningIcon } from "@chakra-ui/icons";
-import { DEFAULT_NFT_TOKEN_SERIAL_ID } from "@services";
+import { DEFAULT_NFT_TOKEN_SERIAL_ID, EDITOR_DEFAULT_CHARACTER_COUNT } from "@services";
 
 export function TokenTransferProposalForm(): ReactElement {
   const navigate = useNavigate();
@@ -103,7 +103,9 @@ export function TokenTransferProposalForm(): ReactElement {
                       control={control}
                       rules={{
                         required: { value: true, message: "Description is required." },
-                        minLength: { value: 107, message: "Please enter atleast 100 characters in the description." },
+                        validate: (value) =>
+                          (value.length > 0 && value.length <= 240 + EDITOR_DEFAULT_CHARACTER_COUNT) ||
+                          "Maximum character count for the description is 240.",
                       }}
                       render={({ field }) => (
                         <TextEditor

--- a/src/dex-ui/pages/Governance/VotingPower/ManageVotingPower.tsx
+++ b/src/dex-ui/pages/Governance/VotingPower/ManageVotingPower.tsx
@@ -173,46 +173,46 @@ function ManageVotingPowerModalBody(props: ManageVotingPowerModalBodyProps) {
             />
           </TabPanel>
           <TabPanel padding="1rem 0">
-            <FormInput<"unLockAmount">
-              inputProps={{
-                id: "unLockAmount",
-                isReadOnly: !isUnlockButtonEnabled,
-                pointerEvents: "all",
-                label: <InputLabel tokenSymbol={props.tokenSymbol} balance={props.lockedGODToken} />,
-                type: "number",
-                unit: (
-                  <RightUnitItem
-                    tokenSymbol={props.tokenSymbol}
-                    handleHalfButtonClicked={handleHalfButtonClicked}
-                    handleMaxButtonClicked={handleMaxButtonClicked}
-                  />
-                ),
-                placeholder: "",
-                register: {
-                  ...props.form.register("unLockAmount", {
-                    validate: (value) =>
-                      Number(value) <= Number(props.lockedGODToken) || "Cannot unlock more than locked balance",
-                  }),
-                },
-              }}
-              isInvalid={Boolean(props.form.formState.errors.unLockAmount)}
-              errorMessage={props.errors.unLockAmount && props.errors.unLockAmount?.message}
-            />
+            {!isUnlockButtonEnabled && tabIndex === ManageVotingPowerTabType.Unlock ? (
+              <Flex width="fit-content" alignItems="center" margin="0px 15px 20px 15px">
+                <Notification
+                  type={NotficationTypes.WARNING}
+                  message={`You have voted on proposals where the voting period is still in progress, so 
+            any unlocked ${props.tokenSymbol} tokens will be pending unlocks until the in-progress
+            proposals are either complete or canceled.`}
+                  textStyle="p small regular"
+                />
+              </Flex>
+            ) : (
+              <FormInput<"unLockAmount">
+                inputProps={{
+                  id: "unLockAmount",
+                  isReadOnly: !isUnlockButtonEnabled,
+                  pointerEvents: "all",
+                  label: <InputLabel tokenSymbol={props.tokenSymbol} balance={props.lockedGODToken} />,
+                  type: "number",
+                  unit: (
+                    <RightUnitItem
+                      tokenSymbol={props.tokenSymbol}
+                      handleHalfButtonClicked={handleHalfButtonClicked}
+                      handleMaxButtonClicked={handleMaxButtonClicked}
+                    />
+                  ),
+                  placeholder: "",
+                  register: {
+                    ...props.form.register("unLockAmount", {
+                      validate: (value) =>
+                        Number(value) <= Number(props.lockedGODToken) || "Cannot unlock more than locked balance",
+                    }),
+                  },
+                }}
+                isInvalid={Boolean(props.form.formState.errors.unLockAmount)}
+                errorMessage={props.errors.unLockAmount && props.errors.unLockAmount?.message}
+              />
+            )}
           </TabPanel>
         </TabPanels>
       </Tabs>
-      {!isUnlockButtonEnabled && tabIndex === ManageVotingPowerTabType.Unlock ? (
-        <Flex width="fit-content" alignItems="center" margin="0px 15px 20px 15px">
-          <Notification
-            type={NotficationTypes.WARNING}
-            message={`You have voted on proposals where the voting period is still in progress, so 
-            any unlocked ${props.tokenSymbol} tokens will be pending unlocks until the in-progress
-            proposals are either complete or canceled.`}
-            textStyle="p small regular"
-          />
-        </Flex>
-      ) : null}
-
       <Button
         variant="primary"
         type="submit"

--- a/src/dex-ui/pages/ProposalDetails/useProposalDetails.tsx
+++ b/src/dex-ui/pages/ProposalDetails/useProposalDetails.tsx
@@ -25,6 +25,8 @@ export function useProposalDetails(proposalId: string | undefined) {
   const areVoteButtonsVisible = !hasVoted && proposal.data?.status === ProposalStatus.Active;
   const isExecuteButtonVisible =
     proposal.data?.status === ProposalStatus.Passed && proposal.data?.state !== ProposalState.Executed;
+  const isCancelButtonVisible =
+    proposal.data?.state !== ProposalState.Executed && proposal.data?.state !== ProposalState.Canceled;
   const isClaimTokenButtonVisible = proposal.data?.state === ProposalState.Executed;
   const statusColor = getStatusColor(proposal.data?.status, proposal.data?.state);
 
@@ -151,6 +153,7 @@ export function useProposalDetails(proposalId: string | undefined) {
     isWalletConnected,
     doesUserHaveGodTokens,
     proposalStatus,
+    isCancelButtonVisible,
     votingPower,
   };
 }

--- a/src/dex-ui/services/constants.ts
+++ b/src/dex-ui/services/constants.ts
@@ -76,6 +76,7 @@ export const TOKEN_USER_KEY =
 export const DEX_TOKEN_PRECISION_VALUE = 8;
 export const DEX_PRECISION = 100000000;
 export const DEBOUNCE_TIME = 500;
+export const EDITOR_DEFAULT_CHARACTER_COUNT = 7;
 
 export const Tokens = Object.freeze({
   TokenASymbol: "LAB49A",

--- a/src/dex-ui/store/swapSlice/swapSlice.ts
+++ b/src/dex-ui/store/swapSlice/swapSlice.ts
@@ -286,7 +286,8 @@ const createSwapSlice: SwapSlice = (set, get): SwapStore => {
           (token: TokenBalanceJson) => token.tokenId === tokenToReceiveId
         )?.balance;
         const isTokenNotAssociated = isNil(tokenToReceiveBalance);
-        if (isTokenNotAssociated) {
+        const isReceivingTokenHbar = isHbarToken(tokenToReceiveId);
+        if (isTokenNotAssociated && !isReceivingTokenHbar) {
           const tokenAssociateTx = new TokenAssociateTransaction()
             .setAccountId(signingAccount)
             .setTokenIds([tokenToReceiveId]);


### PR DESCRIPTION
** Description **
This PR fixes multiple issue's in Prod under Swap, Governance and Manage Voting Power.

**Swap**:
When Swapping any `token` for `HBAR` HBAR was getting associated to wallet which is fixed now.

**Governance**
1.`Cancel` proposal was not available for the active proposals it was only available when proposal is ready for `Execute`, the problem being if proposal was defeated there was not way for the user to get back locked token from `ManageVotingPower` since `GOD Holder` does not allow `unlocking` the tokens. The `cancel button` will be visible until the proposal is not executed or cancelled already.
2. Corrected the UI for Manage Voting Power in case of already active proposals when user goes to `Unlock` tab.


<img width="1790" alt="Screenshot 2023-07-28 at 7 38 08 PM" src="https://github.com/hashgraph/hedera-accelerator-defi-dex-ui/assets/89677167/65fccabe-a871-4a52-8d6f-c47a400809aa">
<img width="1788" alt="Screenshot 2023-07-28 at 7 40 36 PM" src="https://github.com/hashgraph/hedera-accelerator-defi-dex-ui/assets/89677167/35c19965-f055-48d5-bcb0-3ede45b30ef6">
<img width="647" alt="Screenshot 2023-07-28 at 7 44 40 PM" src="https://github.com/hashgraph/hedera-accelerator-defi-dex-ui/assets/89677167/2672da2c-4268-4eba-8188-2361caa7529a">
