### PR TITLE
Fix/DE21946-feat/US34453: fetch member list, updated threshold using new call contract api

### DIFF
--- a/src/dao/hooks/useDAOProposals.tsx
+++ b/src/dao/hooks/useDAOProposals.tsx
@@ -131,8 +131,9 @@ export function useDAOProposals(
             linkToDiscussion,
             transactionType,
           } = proposalInfo;
-          const { amount, receiver, token, _threshold } = data ?? {};
-          const threshold = getThreshold(daoAndSafeLogs, BigNumber.from(_threshold ?? 0));
+          const { amount, receiver, token } = data ?? {};
+          const safeEVMAddress = await DexService.fetchContractEVMAddress(safeAccountId);
+          const threshold = await getThreshold(safeEVMAddress);
           const approvers = getApprovers(proposalLogs, transactionHash);
           const approvalCount = approvers.length;
           const isThresholdReached = approvalCount >= threshold;
@@ -142,7 +143,6 @@ export function useDAOProposals(
           let isAdminApproved = false;
           let parsedData;
           if (isContractUpgradeProposal) {
-            const safeEVMAddress = await DexService.fetchContractEVMAddress(safeAccountId);
             const upgradeProposalData = { ...data };
             const logs = await DexService.fetchContractLogs(upgradeProposalData.proxy);
 

--- a/src/dex/hooks/governance/useAllProposals.tsx
+++ b/src/dex/hooks/governance/useAllProposals.tsx
@@ -10,7 +10,6 @@ const defaultStatusFilter = [...Object.values(ProposalStatus)];
 const proposalStatusSortOrder = [ProposalStatus.Active, ProposalStatus.Passed, ProposalStatus.Failed];
 interface UseAllProposalsProps {
   titleFilter?: string;
-  accountId: string | undefined;
   statusFilters?: ProposalStatus[];
   startDate?: Date | null;
   endDate?: Date | null;
@@ -19,7 +18,7 @@ interface UseAllProposalsProps {
 type UseAllProposalsQueryKey = [GovernanceQueries.Proposals, "list"];
 
 export function useAllProposals(props: UseAllProposalsProps) {
-  const { accountId, startDate, endDate, statusFilters = defaultStatusFilter, titleFilter = "" } = props;
+  const { startDate, endDate, statusFilters = defaultStatusFilter, titleFilter = "" } = props;
 
   function sortProposalCompareFn(proposalA: FormattedProposal, proposalB: FormattedProposal) {
     if (!isNil(proposalA.status) && !isNil(proposalB.status)) {
@@ -55,11 +54,10 @@ export function useAllProposals(props: UseAllProposalsProps) {
 
   return useQuery<Proposal[], Error, FormattedProposal[], UseAllProposalsQueryKey>(
     [GovernanceQueries.Proposals, "list"],
-    async () => DexService.fetchAllProposals(accountId ?? ""),
+    async () => DexService.fetchAllProposals(),
     {
       keepPreviousData: true,
       select: filterFormatSortProposals,
-      enabled: !!accountId,
     }
   );
 }

--- a/src/dex/hooks/governance/useProposal.tsx
+++ b/src/dex/hooks/governance/useProposal.tsx
@@ -6,16 +6,16 @@ import { isNil } from "ramda";
 
 type UseProposalQueryKey = [GovernanceQueries.Proposals, "detail", string | undefined];
 
-export function useProposal(id: string | undefined, accountId: string) {
+export function useProposal(id: string | undefined) {
   return useQuery<Proposal | undefined, Error, Proposal, UseProposalQueryKey>(
     [GovernanceQueries.Proposals, "detail", id],
     async () => {
       if (isNil(id)) return;
-      return DexService.fetchProposal(id, accountId);
+      return DexService.fetchProposal(id);
     },
     {
       keepPreviousData: true,
-      enabled: !!accountId,
+      enabled: !!id,
     }
   );
 }

--- a/src/dex/pages/Governance/Governance.tsx
+++ b/src/dex/pages/Governance/Governance.tsx
@@ -4,7 +4,7 @@ import { ReactElement, useState } from "react";
 import { Notification, NotficationTypes, CardList, Pagination, usePagination, RangeDatePicker } from "@shared/ui-kit";
 import { createHashScanTransactionLink } from "@dex/utils";
 import { CardListLayout, Page, PageHeader, TabFilter, TabFilters } from "@dex/layouts";
-import { useAllProposals, useTabFilters, useDexContext } from "@dex/hooks";
+import { useAllProposals, useTabFilters } from "@dex/hooks";
 import { ProposalStatus } from "../../store/governanceSlice";
 import { ProposalCard } from "./ProposalCard";
 import { useInput } from "../../hooks/useInput";
@@ -38,8 +38,6 @@ export const Governance = (): ReactElement => {
   const { tabIndex, handleTabChange } = useTabFilters();
   const { value: proposalTitleFilter, handleChange: handleProposalTitleFilterChange } = useInput<string>("");
   const { startDate, endDate, handleChange: handleProposalDatesFilterChange } = useDateRange(null, null);
-  const { wallet } = useDexContext(({ wallet }) => ({ wallet }));
-  const accountId = wallet.savedPairingData?.accountIds[0];
   const {
     data: proposals,
     error,
@@ -51,7 +49,6 @@ export const Governance = (): ReactElement => {
     statusFilters: proposalTabFilters.at(tabIndex)?.filters,
     startDate,
     endDate,
-    accountId,
   });
   const {
     paginatedData: paginatedProposals,

--- a/src/dex/pages/ProposalDetails/useProposalDetails.tsx
+++ b/src/dex/pages/ProposalDetails/useProposalDetails.tsx
@@ -13,7 +13,7 @@ import { Contracts } from "@dex/services";
 export function useProposalDetails(proposalId: string | undefined) {
   const { wallet } = useDexContext(({ wallet }) => ({ wallet }));
   const walletId = wallet?.savedPairingData?.accountIds[0] ?? "";
-  const proposal = useProposal(proposalId, walletId);
+  const proposal = useProposal(proposalId);
   const castVote = useCastVote(proposalId);
   const cancelProposal = useCancelProposal(proposalId);
   const hasVoted = proposal.data?.voted ?? false;

--- a/src/dex/services/constants.ts
+++ b/src/dex/services/constants.ts
@@ -99,3 +99,4 @@ export const DEFAULT_NFT_TOKEN_SERIAL_ID = 0;
 export const MINIMUM_DEPOSIT_AMOUNT = 1;
 
 export const Gas = 9000000;
+export const GasPrice = 100000000;

--- a/src/shared/services/MirrorNodeService/MirrorNodeService.ts
+++ b/src/shared/services/MirrorNodeService/MirrorNodeService.ts
@@ -19,6 +19,7 @@ import { LogDescription } from "ethers/lib/utils";
 import { AccountId, ContractId } from "@hashgraph/sdk";
 import { abiSignatures } from "./constants";
 import { decodeLog } from "./utils";
+import { Gas, GasPrice } from "@dex/services";
 
 const TESTNET_URL = `https://testnet.mirrornode.hedera.com`;
 /* TODO: Enable for Mainnet usage.
@@ -162,8 +163,9 @@ function createMirrorNodeService() {
    * @param payload -
    * @returns Results from a cost-free EVM call to the contract.
    */
+
   const callContract = async (payload: CallContractParams): Promise<any> => {
-    const { block, data, estimate, from, gas, gasPrice, to, value } = payload;
+    const { block = "latest", data, estimate = false, from, gas = Gas, gasPrice = GasPrice, to, value = 0 } = payload;
     return await testnetMirrorNodeAPI.post(`/api/v1/contracts/call`, {
       block,
       data,


### PR DESCRIPTION
**Description**
With latest testing it came out the user is not able to remove the member using proposal in MultiSig DAO.
With recent addition of admin as member the member list was not in correct order since we need to send `prevOwner` as parameter in order to create a proposal.

With new `callContract` API available we can not fetch exact list of owners in actual order rather reading and making a list of member operations. this solves the problem.