### PR TITLE
ci: Update self-hosted runner group and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+###################################
+##### Global Protection Rule ######
+###################################
+# NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below
+*                                              @hashgraph/developer-advocates
+
+#########################
+#####  Core Files  ######
+#########################
+
+# NOTE: Must be placed last to ensure enforcement over all other rules
+
+# Protection Rules for Github Configuration Files and Actions Workflows
+/.github/                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/release-engineering-managers
+
+# Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
+/CODEOWNERS                                      @hashgraph/release-engineering-managers
+
+# Protect the repository root files
+/README.md                                      @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/LICENSE                                      @hashgraph/release-engineering-managers
+
+# Git Ignore definitions
+**/.gitignore                                   @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/.gitignore.*                                 @hashgraph/devops-ci @hashgraph/release-engineering-managers

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-test-deploy-prod:
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: defi-dex-linux-medium
     
     steps:
     - name: Harden Runner

--- a/.github/workflows/production-pull-request.yml
+++ b/.github/workflows/production-pull-request.yml
@@ -7,7 +7,7 @@ on:
    
 jobs:
   build-test-deploy-prod:
-    runs-on: [self-hosted, Linux, medium, ephemeral]
+    runs-on: defi-dex-linux-medium
     
     steps:
       - name: Harden Runner


### PR DESCRIPTION
**Description**:

Updates the self-hosted runner label to be defi-dex-linux-medium runner group. Adds CODEOWNERS to the repo.

**Related issue(s)**:

Fixes #355
